### PR TITLE
fix: check chain before sending transactions

### DIFF
--- a/src/executionFiles/allowance.execute.ts
+++ b/src/executionFiles/allowance.execute.ts
@@ -38,14 +38,14 @@ export const checkAllowance = async (
 
       if (new BigNumber(amount).gt(approved)) {
         if (!allowUserInteraction) return
-        const approvaLAmount = infiniteApproval
+        const approvalAmount = infiniteApproval
           ? constants.MaxUint256.toString()
           : amount
         const approveTx = await setApproval(
           signer,
           token.address,
           spenderAddress,
-          approvaLAmount
+          approvalAmount
         )
 
         // update currentExecution

--- a/src/executionFiles/bridges/nxtp.execute.ts
+++ b/src/executionFiles/bridges/nxtp.execute.ts
@@ -29,6 +29,7 @@ import {
 } from '../../utils/parseError'
 import { LifiErrorCodes, RPCError } from '../../utils/errors'
 import { Action } from '@lifinance/types'
+import { switchChain } from '../switchChain'
 
 export class NXTPExecutionManager {
   shouldContinue = true
@@ -134,6 +135,22 @@ export class NXTPExecutionManager {
           }
 
           // STEP 3: Send Transaction ///////////////////////////////////////////////
+          // make sure that chain is still correct
+          const updatedSigner = await switchChain(
+            signer,
+            statusManager,
+            step,
+            hooks.switchChainHook,
+            this.shouldContinue
+          )
+
+          if (!updatedSigner) {
+            // chain switch was not successful, stop execution here
+            return step.execution
+          }
+
+          signer = updatedSigner
+
           statusManager.updateProcess(step, crossProcess.id, 'ACTION_REQUIRED')
           if (!this.shouldContinue) return step.execution
 

--- a/src/executionFiles/switchChain.ts
+++ b/src/executionFiles/switchChain.ts
@@ -1,0 +1,62 @@
+import { getChainById, SwitchChainHook } from '../types'
+import { Signer } from 'ethers'
+import StatusManager from '../StatusManager'
+import { Step } from '@lifinance/types'
+
+/**
+ * This method checks whether the signer is configured for the correct chain.
+ * If yes it returns the signer.
+ * If no and if user interaction is allowed it triggers the switchChainHook. If no user interaction is allowed it aborts.
+ *
+ * @param signer
+ * @param statusManager
+ * @param step
+ * @param switchChainHook
+ * @param allowUserInteraction
+ */
+export const switchChain = async (
+  signer: Signer,
+  statusManager: StatusManager,
+  step: Step,
+  switchChainHook: SwitchChainHook,
+  allowUserInteraction: boolean
+): Promise<Signer | undefined> => {
+  // if we are already on the correct chain we can proceed directly
+  if ((await signer.getChainId()) === step.action.fromChainId) {
+    return signer
+  }
+
+  // -> set status message
+  step.execution = statusManager.initExecutionObject(step)
+  statusManager.updateExecution(step, 'CHAIN_SWITCH_REQUIRED')
+  const chain = getChainById(step.action.fromChainId)
+
+  const switchProcess = statusManager.findOrCreateProcess(
+    'switchProcess',
+    step,
+    `Change Chain to ${chain.name}`
+  )
+
+  if (!allowUserInteraction) return
+
+  try {
+    const updatedSigner = await switchChainHook(step.action.fromChainId)
+    if (
+      !updatedSigner ||
+      (await updatedSigner.getChainId()) !== step.action.fromChainId
+    ) {
+      throw new Error('CHAIN SWITCH REQUIRED')
+    }
+
+    statusManager.removeProcess(step, switchProcess.id)
+    statusManager.updateExecution(step, 'PENDING')
+    return updatedSigner
+  } catch (e: any) {
+    statusManager.updateProcess(step, switchProcess.id, 'FAILED', {
+      errorMessage: e.message,
+      errorCode: e.code,
+    })
+    statusManager.updateExecution(step, 'FAILED')
+    throw e
+  }
+}

--- a/src/executionFiles/switchChain.unit.spec.ts
+++ b/src/executionFiles/switchChain.unit.spec.ts
@@ -1,0 +1,173 @@
+import { buildStepObject } from '../../test/fixtures'
+import { Step } from '@lifinance/types'
+import { Signer } from 'ethers'
+import { switchChain } from './switchChain'
+import StatusManager from '../StatusManager'
+import { Hooks } from '../types'
+
+let signer: Signer,
+  step: Step,
+  statusManager: StatusManager,
+  hooks: Hooks,
+  getChainIdMock: jest.Mock,
+  switchChainHookMock: jest.Mock,
+  findOrCreateProcessMock: jest.Mock,
+  updateExecutionMock: jest.Mock,
+  updateProcessMock: jest.Mock
+
+describe('switchChain', () => {
+  beforeEach(() => {
+    getChainIdMock = jest.fn()
+    signer = {
+      getChainId: getChainIdMock,
+    } as unknown as Signer
+
+    switchChainHookMock = jest.fn()
+    hooks = {
+      switchChainHook: switchChainHookMock,
+    } as unknown as Hooks
+
+    step = buildStepObject({ includingExecution: false })
+
+    findOrCreateProcessMock = jest.fn()
+    updateExecutionMock = jest.fn()
+    updateProcessMock = jest.fn()
+    statusManager = {
+      initExecutionObject: jest.fn(),
+      findOrCreateProcess: findOrCreateProcessMock,
+      removeProcess: jest.fn(),
+      updateExecution: updateExecutionMock,
+      updateProcess: updateProcessMock,
+    } as unknown as StatusManager
+  })
+
+  describe('when the chain is already correct', () => {
+    beforeEach(() => {
+      getChainIdMock.mockResolvedValue(step.action.fromChainId)
+    })
+
+    it('should return the signer and do nothing else', async () => {
+      const updatedSigner = await switchChain(
+        signer,
+        statusManager,
+        step,
+        hooks.switchChainHook,
+        true
+      )
+
+      expect(updatedSigner).toEqual(signer)
+      expect(statusManager.initExecutionObject).not.toHaveBeenCalled()
+      expect(hooks.switchChainHook).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('when the chain is not correct', () => {
+    beforeEach(() => {
+      getChainIdMock.mockResolvedValueOnce(1)
+      findOrCreateProcessMock.mockReturnValue({ id: 'switchProcess' })
+    })
+
+    describe('when allowUserInteraction is false', () => {
+      it('should initialize the status manager and abort', async () => {
+        const updatedSigner = await switchChain(
+          signer,
+          statusManager,
+          step,
+          hooks.switchChainHook,
+          false
+        )
+
+        expect(updatedSigner).toBeUndefined()
+
+        expect(statusManager.initExecutionObject).toHaveBeenCalled()
+        expect(statusManager.findOrCreateProcess).toHaveBeenCalled()
+        expect(hooks.switchChainHook).not.toHaveBeenCalled()
+      })
+    })
+
+    describe('when allowUserInteraction is true', () => {
+      describe('when the switchChainHook fails', () => {
+        beforeEach(() => {
+          switchChainHookMock.mockRejectedValue(
+            new Error('something went wrong')
+          )
+        })
+
+        it('should throw the error', async () => {
+          await expect(
+            switchChain(
+              signer,
+              statusManager,
+              step,
+              hooks.switchChainHook,
+              true
+            )
+          ).rejects.toThrowError(new Error('something went wrong'))
+
+          expect(switchChainHookMock).toHaveBeenCalledWith(
+            step.action.fromChainId
+          )
+          expect(updateExecutionMock).toHaveBeenCalledWith(step, 'FAILED')
+        })
+      })
+
+      describe("when the switchChainHook doesn't change the chain", () => {
+        beforeEach(() => {
+          switchChainHookMock.mockResolvedValue(signer)
+        })
+
+        it('should throw the error', async () => {
+          await expect(
+            switchChain(
+              signer,
+              statusManager,
+              step,
+              hooks.switchChainHook,
+              true
+            )
+          ).rejects.toThrowError(new Error('CHAIN SWITCH REQUIRED'))
+
+          expect(switchChainHookMock).toHaveBeenCalledWith(
+            step.action.fromChainId
+          )
+          expect(updateExecutionMock).toHaveBeenCalledWith(step, 'FAILED')
+        })
+      })
+
+      describe('when the switchChainHook changes the chain', () => {
+        let newSigner: Signer
+
+        beforeEach(() => {
+          newSigner = {
+            getChainId: () => Promise.resolve(step.action.fromChainId),
+          } as unknown as Signer
+
+          switchChainHookMock.mockResolvedValue(newSigner)
+        })
+
+        it('should return the updated signer', async () => {
+          const updatedSigner = await switchChain(
+            signer,
+            statusManager,
+            step,
+            hooks.switchChainHook,
+            true
+          )
+
+          expect(switchChainHookMock).toHaveBeenCalledWith(
+            step.action.fromChainId
+          )
+          expect(updatedSigner).toEqual(newSigner)
+          expect(statusManager.removeProcess).toHaveBeenCalledWith(
+            step,
+            'switchProcess'
+          )
+          expect(statusManager.updateExecution).toHaveBeenCalledWith(
+            step,
+            'PENDING'
+          )
+        })
+      })
+    })
+  })
+})

--- a/src/types/internal.types.ts
+++ b/src/types/internal.types.ts
@@ -39,6 +39,7 @@ export type ExecuteSwapParams = {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   parseReceipt: (...args: any[]) => Promise<ParsedReceipt>
   statusManager: StatusManager
+  hooks: Hooks
 }
 
 export type ExecuteCrossParams = {


### PR DESCRIPTION
Switching chains while preparing transaction (`Lifi.getStepTransaction`) causes an unexpected failure when trying to send the transaction (`signer.sendTransaction`) because the signer is configured for the wrong chain.
To prevent that we need to check here again that the user is on the correct chain.