### PR TITLE
build: add action to release beta versions

### DIFF
--- a/.github/workflows/beta-release.yml
+++ b/.github/workflows/beta-release.yml
@@ -1,0 +1,59 @@
+name: Release & Publish
+
+on:
+  push:
+    paths-ignore:
+      - 'docs/**'
+      - 'README.md'
+      - 'LICENSE'
+      - '.editorconfig'
+    branches:
+      - main
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: Create Release
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ github.ref }}
+          release_name: ${{ github.ref }}
+          draft: false
+          prerelease: true
+
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Setup .npmrc file to publish to npm
+        uses: actions/setup-node@v1
+        with:
+          node-version: '14.x'
+          registry-url: 'https://registry.npmjs.org'
+      - name: Install modules
+        run: yarn install
+      - name: Build
+        run: yarn build
+      - name: Create release
+        run: yarn release --prerelease beta
+      - name: Publish to npm
+        run: npm publish --access public --tag beta
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+      - name: Setup .npmrc file to publish to GitHub Packages
+        uses: actions/setup-node@v1
+        with:
+          node-version: '14.x'
+          registry-url: 'https://npm.pkg.github.com'
+          scope: '@lifinance'
+      - run: npm run addscope
+      - name: Publish to GitHub Packages
+        run: npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/beta-release.yml
+++ b/.github/workflows/beta-release.yml
@@ -1,4 +1,4 @@
-name: Release & Publish
+name: Beta Release
 
 on:
   push:
@@ -14,22 +14,6 @@ on:
       - LF-384 # TODO: for testing
 
 jobs:
-  release:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v2
-      - name: Create Release
-        id: create_release
-        uses: actions/create-release@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          tag_name: ${{ github.ref }}
-          release_name: ${{ github.ref }}
-          draft: false
-          prerelease: true
-
   publish:
     runs-on: ubuntu-latest
     steps:
@@ -43,6 +27,10 @@ jobs:
         run: yarn install
       - name: Build
         run: yarn build
+      - name: Configure committer
+        run: |
+          git config user.name "Li.Finance"
+          git config user.email "<>"
       - name: Create release
         run: yarn release --prerelease beta
       - name: Publish to npm

--- a/.github/workflows/beta-release.yml
+++ b/.github/workflows/beta-release.yml
@@ -11,6 +11,7 @@ on:
       - '*'
     branches:
       - main
+      - LF-384 # TODO: for testing
 
 jobs:
   release:

--- a/.github/workflows/beta-release.yml
+++ b/.github/workflows/beta-release.yml
@@ -11,7 +11,6 @@ on:
       - '*'
     branches:
       - main
-      - LF-384 # TODO: for testing
 
 jobs:
   publish:

--- a/.github/workflows/beta-release.yml
+++ b/.github/workflows/beta-release.yml
@@ -7,6 +7,8 @@ on:
       - 'README.md'
       - 'LICENSE'
       - '.editorconfig'
+    tags-ignore:
+      - '*'
     branches:
       - main
 

--- a/package.json
+++ b/package.json
@@ -5,7 +5,6 @@
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "scripts": {
-    "install": "node -e \"if (!require('fs').existsSync('./dist')){process.exit(1)}\" || npm run build",
     "watch": "tsc -w -p ./tsconfig.json",
     "build": "yarn clean && tsc --project ./tsconfig.json",
     "clean": "node tools/cleanup",


### PR DESCRIPTION
This action will create and publish beta releases to Github and NPM.
* It listens to pushes to the `main` branch
* It bumps the version number to a beta version (e.g. `0.4.4-beta.0`)
* It updates the changelog 
![image](https://user-images.githubusercontent.com/8833906/152979264-11854678-ddc2-48a6-a45a-55dadc6dd678.png)
* Those changes are not persisted in the branch. That means that in normal releases the beta information will not be in the changelog, which is intended
