### PR TITLE
feat: use common bridge executor for all known BridgeTools

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
   "dependencies": {
     "@ethersproject/abi": "^5.5.0",
     "@ethersproject/contracts": "^5.4.0",
-    "@lifinance/types": "0.10.5",
+    "@lifinance/types": "0.10.7",
     "axios": "^0.25.0",
     "bignumber.js": "^9.0.1",
     "eth-rpc-errors": "^4.0.3",

--- a/src/executionFiles/StepExecutor.ts
+++ b/src/executionFiles/StepExecutor.ts
@@ -121,16 +121,14 @@ export class StepExecutor {
       statusManager: this.statusManager,
     }
 
-    switch (step.tool) {
-      case BridgeTool.connext:
-      case 'nxtp': // keep for some time while user still may have unfinished routes locally
-      case BridgeTool.cbridge:
-      case BridgeTool.multichain:
-      case 'anyswap': // keep for some time while user still may have unfinished routes locally
-      case BridgeTool.hop:
-        return await this.bridgeExecutionManager.execute(crossParams)
-      default:
-        throw new Error('Should never reach here, bridge not defined')
+    let stepTool = step.tool
+    if (step.tool === 'nxtp') stepTool = BridgeTool.connext // keep for some time while user still may have unfinished routes locally
+    if (step.tool === 'anyswap') stepTool = BridgeTool.multichain // keep for some time while user still may have unfinished routes locally
+
+    if (Object.values<string>(BridgeTool).includes(stepTool)) {
+      return await this.bridgeExecutionManager.execute(crossParams)
+    } else {
+      throw new Error('Should never reach here, bridge not defined')
     }
   }
 }

--- a/src/executionFiles/StepExecutor.ts
+++ b/src/executionFiles/StepExecutor.ts
@@ -2,7 +2,6 @@ import { Signer } from 'ethers'
 import StatusManager from '../StatusManager'
 
 import {
-  BridgeTool,
   CrossStep,
   ExchangeTool,
   Hooks,
@@ -121,14 +120,6 @@ export class StepExecutor {
       statusManager: this.statusManager,
     }
 
-    let stepTool = step.tool
-    if (step.tool === 'nxtp') stepTool = BridgeTool.connext // keep for some time while user still may have unfinished routes locally
-    if (step.tool === 'anyswap') stepTool = BridgeTool.multichain // keep for some time while user still may have unfinished routes locally
-
-    if (Object.values<string>(BridgeTool).includes(stepTool)) {
-      return await this.bridgeExecutionManager.execute(crossParams)
-    } else {
-      throw new Error('Should never reach here, bridge not defined')
-    }
+    return await this.bridgeExecutionManager.execute(crossParams)
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1029,10 +1029,10 @@
     "@jridgewell/resolve-uri" "^3.0.3"
     sourcemap-codec "1.4.8"
 
-"@lifinance/types@0.10.5":
-  version "0.10.5"
-  resolved "https://registry.yarnpkg.com/@lifinance/types/-/types-0.10.5.tgz#098df60e20675828042f269787c114035ca1859f"
-  integrity sha512-1lXQTPppB09z1ctVj9NwouMXNJ0kOGmr003+JYivmGtRRTB9vBS0FZquMsPWe/bNQmNrbN+cD04HX6KSNH8ZoA==
+"@lifinance/types@0.10.7":
+  version "0.10.7"
+  resolved "https://registry.yarnpkg.com/@lifinance/types/-/types-0.10.7.tgz#5ed6a057a7d913f17b7fccc2c55a52c1ade2d601"
+  integrity sha512-Wk/hs9YFiMNBNlvU3BS+/1QskrhdC9NkOZfJ70UQrrX1JDTcrX1QUDKumjWl5oqrhn/TtCkPbrQNIyoBBupNDw==
   dependencies:
     ethers "^5.4.7"
 


### PR DESCRIPTION
All our bridges now support the /status endpoint and can be handled with the general handler. 
This also implicitly adds Hyphen bridge support :)
