### PR TITLE
fix: store received token in execution object

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
   "dependencies": {
     "@ethersproject/abi": "^5.5.0",
     "@ethersproject/contracts": "^5.4.0",
-    "@lifinance/types": "0.10.8",
+    "@lifinance/types": "0.10.12",
     "axios": "^0.25.0",
     "bignumber.js": "^9.0.1",
     "eth-rpc-errors": "^4.0.3",

--- a/src/StatusManager.ts
+++ b/src/StatusManager.ts
@@ -7,12 +7,14 @@ import {
   Route,
   Status,
   Step,
+  Token,
 } from './types'
 import { deepClone } from './utils/utils'
 
 interface Receipt {
   fromAmount?: string
   toAmount?: string
+  toToken?: Token
 }
 
 type InternalUpdateRouteCallback = (route: Route) => void
@@ -80,6 +82,7 @@ export default class StatusManager {
     if (receipt) {
       step.execution.fromAmount = receipt.fromAmount
       step.execution.toAmount = receipt.toAmount
+      step.execution.toToken = receipt.toToken
     }
     this.updateStepInRoute(step)
     return step

--- a/src/executionFiles/bridges/bridge.execute.ts
+++ b/src/executionFiles/bridges/bridge.execute.ts
@@ -176,6 +176,7 @@ export class BridgeExecutionManager {
     statusManager.updateExecution(step, 'DONE', {
       fromAmount: statusResponse.sending.amount,
       toAmount: statusResponse.receiving?.amount,
+      toToken: statusResponse.receiving?.token,
       // gasUsed: statusResponse.gasUsed,
     })
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1029,10 +1029,10 @@
     "@jridgewell/resolve-uri" "^3.0.3"
     sourcemap-codec "1.4.8"
 
-"@lifinance/types@0.10.8":
-  version "0.10.8"
-  resolved "https://registry.yarnpkg.com/@lifinance/types/-/types-0.10.8.tgz#3d466ce935227bb855221fc3f478be45fb09555c"
-  integrity sha512-dsHZ3/760tsGk9lTTacJqQjVsGGLWRMah7bBlX3HmYD8+eki5zWTwX1kIFArdeTU6b1FPkajRfpg7Zjh6AQ0fg==
+"@lifinance/types@0.10.12":
+  version "0.10.12"
+  resolved "https://registry.yarnpkg.com/@lifinance/types/-/types-0.10.12.tgz#302587902dad10743ad98370a85af6b111c38b3f"
+  integrity sha512-OOJm/hK0CPT0Znq+qB8MlqNmWBnbvPVEvoYkdeBlFYb06yQGitcrT+RLyjkiweZNbr+/o+AZFcwFPLddkB9HDA==
   dependencies:
     ethers "^5.4.7"
 


### PR DESCRIPTION
It can be that the received token changes due to failures in the destination swap. To be able to show the received token we need to store it in the execution object.

(Requires [types release](https://github.com/lifinance/types/pull/34))
