### PR TITLE
fix: continue status calls after failure

### DIFF
--- a/src/executionFiles/bridges/bridge.execute.ts
+++ b/src/executionFiles/bridges/bridge.execute.ts
@@ -201,12 +201,12 @@ export class BridgeExecutionManager {
             txHash
           )
         } catch (e: any) {
-          // until the source transaction is mined the API will return a 404
-          if (e.code === LifiErrorCodes.notFound) {
-            return resolve(undefined)
+          // until the source transaction is mined the API will return a 404, which is not really an error
+          if (e.code !== LifiErrorCodes.notFound) {
+            console.debug('Fetching status from backend failed', e)
           }
 
-          return reject(e)
+          return resolve(undefined)
         }
 
         switch (statusResponse.status) {


### PR DESCRIPTION
We should always continue querying the status endpoint, even if it fails at some point. We hope that the BE recovers and that following requests are successful.