### PR TITLE
fix: handle status result 'FAILED' correctly

### DIFF
--- a/src/executionFiles/bridges/bridge.execute.ts
+++ b/src/executionFiles/bridges/bridge.execute.ts
@@ -164,7 +164,7 @@ export class BridgeExecutionManager {
     } catch (e: any) {
       statusManager.updateProcess(step, waitForTxProcess.id, 'FAILED', {
         errorMessage: 'Transaction failed',
-        htmlErrorMessage: await getTransactionFailedMessage(crossProcess),
+        htmlErrorMessage: getTransactionFailedMessage(crossProcess),
         errorCode: e?.code,
       })
       statusManager.updateExecution(step, 'FAILED')

--- a/src/executionFiles/bridges/bridge.execute.ts
+++ b/src/executionFiles/bridges/bridge.execute.ts
@@ -1,7 +1,10 @@
 import { TransactionResponse } from '@ethersproject/abstract-provider'
 import { constants } from 'ethers'
 
-import { parseWalletError } from '../../utils/parseError'
+import {
+  getTransactionFailedMessage,
+  parseWalletError,
+} from '../../utils/parseError'
 import { ExecuteCrossParams } from '../../types'
 import { personalizeStep, repeatUntilDone } from '../../utils/utils'
 import { checkAllowance } from '../allowance.execute'
@@ -160,7 +163,8 @@ export class BridgeExecutionManager {
       )
     } catch (e: any) {
       statusManager.updateProcess(step, waitForTxProcess.id, 'FAILED', {
-        errorMessage: 'Failed waiting',
+        errorMessage: 'Transaction failed',
+        htmlErrorMessage: await getTransactionFailedMessage(crossProcess),
         errorCode: e?.code,
       })
       statusManager.updateExecution(step, 'FAILED')

--- a/src/utils/parseError.ts
+++ b/src/utils/parseError.ts
@@ -78,9 +78,7 @@ export const getTransactionNotSentMessage = async (
   return transactionNotSend
 }
 
-export const getTransactionFailedMessage = async (
-  process: Process
-): Promise<string> => {
+export const getTransactionFailedMessage = (process: Process): string => {
   return process.txLink
     ? `Please check the&nbsp;<a href="${process.txLink}" target="_blank" rel="nofollow noreferrer">block explorer</a> for more information.`
     : ''

--- a/src/utils/parseError.ts
+++ b/src/utils/parseError.ts
@@ -78,6 +78,14 @@ export const getTransactionNotSentMessage = async (
   return transactionNotSend
 }
 
+export const getTransactionFailedMessage = async (
+  process: Process
+): Promise<string> => {
+  return process.txLink
+    ? `Please check the&nbsp;<a href="${process.txLink}" target="_blank" rel="nofollow noreferrer">block explorer</a> for more information.`
+    : ''
+}
+
 export const parseWalletError = async (
   e: any,
   step?: Step,


### PR DESCRIPTION
So far we treated a `failed` waiting attempt as "Failed waiting". That's not correct since we query the endpoint until we find a result.
This result can be `FAILED`. In this case we need to show a proper error message.
Before:
![Screen Shot 2022-04-12 at 12 03 43](https://user-images.githubusercontent.com/8833906/162936889-343448df-06f5-426f-b3f4-cea68524e89c.png)
Now: 
![Screen Shot 2022-04-12 at 12 07 02](https://user-images.githubusercontent.com/8833906/162936959-98cdda80-0637-4570-88de-c49da3ffbb65.png)

