### PR TITLE
fix: added toolDetails + workaround for non EVM chains testing

### DIFF
--- a/src/services/ApiService.unit.spec.ts
+++ b/src/services/ApiService.unit.spec.ts
@@ -539,6 +539,11 @@ describe('ApiService', () => {
       id,
       type,
       tool,
+      toolDetails: {
+        key: tool,
+        name: tool,
+        logoURI: '',
+      },
       action,
       estimate,
       includedSteps: [],

--- a/src/services/ChainsService.unit.spec.ts
+++ b/src/services/ChainsService.unit.spec.ts
@@ -1,4 +1,10 @@
-import { AddEthereumChainParameter, Chain, ChainKey, CoinKey } from '../types'
+import {
+  AddEthereumChainParameter,
+  Chain,
+  ChainKey,
+  ChainType,
+  CoinKey,
+} from '../types'
 import { ValidationError } from '../utils/errors'
 import ApiService from './ApiService'
 import ChainsService from './ChainsService'
@@ -9,6 +15,7 @@ const mockedApiService = ApiService as jest.Mocked<typeof ApiService>
 let chainsService: ChainsService
 
 const chain1: Chain = {
+  chainType: ChainType.EVM,
   key: ChainKey.ETH,
   name: 'Ethereum',
   coin: CoinKey.ETH,
@@ -18,6 +25,7 @@ const chain1: Chain = {
 }
 
 const chain2: Chain = {
+  chainType: ChainType.EVM,
   key: ChainKey.POL,
   name: 'Polygon',
   coin: CoinKey.MATIC,

--- a/src/services/ConfigService.unit.spec.ts
+++ b/src/services/ConfigService.unit.spec.ts
@@ -1,4 +1,4 @@
-import { ChainId, supportedChains } from '../types'
+import { ChainId, ChainType, getChainById, supportedChains } from '../types'
 import ConfigService from './ConfigService'
 
 let configService: ConfigService
@@ -116,6 +116,15 @@ describe('ConfigService', () => {
     it('should set rpcs/multicall address', () => {
       const config = configService.updateChains(supportedChains)
       for (const chainId of Object.values(ChainId)) {
+        // This is a workaround until we complete the transition to
+        // supporting non EVM chains.
+        try {
+          // This will fail with SOL, SOLT, TER, TERT, OAS, OAST
+          // as getChainById(ChainId) returns EVMChain
+          getChainById(Number(chainId))
+        } catch {
+          continue
+        }
         if (typeof chainId !== 'string') {
           expect(config.rpcs[chainId].length).toBeGreaterThan(0)
         }

--- a/test/fixtures.ts
+++ b/test/fixtures.ts
@@ -21,6 +21,12 @@ export const buildStepObject = ({
   id: '8d3a0474-4ee3-4a7a-90c7-2a2264b7f3a9',
   type: 'swap',
   tool: '1inch',
+  toolDetails: {
+    key: '1inch',
+    name: '1inch',
+    logoURI:
+      'https://raw.githubusercontent.com/lifinance/types/main/src/assets/icons/exchanges/oneinch.png',
+  },
   action: {
     fromChainId: 137,
     toChainId: 137,

--- a/yarn.lock
+++ b/yarn.lock
@@ -1183,10 +1183,17 @@
     "@jridgewell/resolve-uri" "^3.0.3"
     "@jridgewell/sourcemap-codec" "^1.4.10"
 
+<<<<<<< Updated upstream
 "@lifinance/types@^0.14.0":
   version "0.14.0"
   resolved "https://registry.yarnpkg.com/@lifinance/types/-/types-0.14.0.tgz#0f900712574ea5218218a1948893010009636428"
   integrity sha512-bsd/V/O+is0wHVw8N0dTlnJawXPRU5nUOpJQXQnQvuoYzOl1sXTL++HZZvP69TjeM6D+AelXbYBJ84aJclPyCw==
+=======
+"@lifinance/types@0.13.1":
+  version "0.13.1"
+  resolved "https://registry.yarnpkg.com/@lifinance/types/-/types-0.13.1.tgz#31aede31c4fad530c42a7891e33dc4357319ab19"
+  integrity sha512-cC8GzTHPnQwjAuv5wHPESRz+F8qt67HKifSSNACfemPbCEezErlYhEkyArKYTtZzr3zgsOWx7crGCis/h/w1bQ==
+>>>>>>> Stashed changes
   dependencies:
     ethers "^5.6.5"
 


### PR DESCRIPTION
This PR adds the toolDetails property in literal objects and fixes a test that required non EVM chains to have RPC / Multicall information. The latter is a temporary fix while we add complete support for nonEVM chains.