### PR TITLE
feat: handle slippage errors

### DIFF
--- a/src/utils/errors.ts
+++ b/src/utils/errors.ts
@@ -6,6 +6,7 @@ enum ErrorType {
   ValidationError = 'ValidationError',
   NotFoundError = 'NotFoundError',
   UnknownError = 'UnknownError',
+  SlippageError = 'SlippageError',
 }
 
 export enum LifiErrorCode {
@@ -18,6 +19,7 @@ export enum LifiErrorCode {
   ProviderUnavailable = 1005,
   NotFound = 1006,
   ChainSwitchError = 1007,
+  SlippageError = 1008,
 }
 
 export enum MetaMaskRPCErrorCode {
@@ -59,6 +61,9 @@ export class LifiError extends Error {
     stack?: string
   ) {
     super(message)
+
+    // Set the prototype explicitly: https://github.com/Microsoft/TypeScript/wiki/Breaking-Changes#extending-built-ins-like-error-array-and-map-may-no-longer-work
+    Object.setPrototypeOf(this, LifiError.prototype)
 
     this.code = code
 
@@ -128,6 +133,18 @@ export class TransactionError extends LifiError {
     stack?: string
   ) {
     super(ErrorType.TransactionError, code, message, htmlMessage, stack)
+  }
+}
+
+export class SlippageError extends LifiError {
+  constructor(message: string, htmlMessage?: string, stack?: string) {
+    super(
+      ErrorType.SlippageError,
+      LifiErrorCode.SlippageError,
+      message,
+      htmlMessage,
+      stack
+    )
   }
 }
 

--- a/src/utils/parseError.ts
+++ b/src/utils/parseError.ts
@@ -11,6 +11,7 @@ import {
   ProviderError,
   RPCError,
   ServerError,
+  SlippageError,
   TransactionError,
   UnknownError,
   ValidationError,
@@ -90,6 +91,10 @@ export const parseError = async (
   step?: Step,
   process?: Process
 ): Promise<LifiError> => {
+  if (e instanceof LifiError) {
+    return e
+  }
+
   if (e.code) {
     // MetaMask errors have a numeric error code
     if (typeof e.code === 'number') {
@@ -168,6 +173,14 @@ export const parseBackendError = (e: any): LifiError => {
     return new NotFoundError(
       e.response?.data?.message || e.response?.statusText,
       undefined,
+      e.stack
+    )
+  }
+
+  if (e.response?.status === 409) {
+    return new SlippageError(
+      e.response?.data?.message || e.response?.statusText,
+      'The slippage is larger than the defined threshold. Please request a new route to get a fresh quote.',
       e.stack
     )
   }


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/8833906/176159826-afee4135-5869-42af-bc7a-977dad5bc0e4.png)

So far we never actually handled the case that between a /routes request and the according /getStepTransaction the quote changed more than the defined slippage.
We need proper handling in the FE to ask the user if they are fine with the new (bad) quote or if they want to abort.
This is on the roadmap.
As a quick solution we decided that the Backend throws an SlippageError if the slippage is 2x the defined slippage. We decided for this large amount to not cause to many failures until we have the real update logic in place. The problem is that this could also happen in the second or third step of a route where the funds of the user already moved a bit. That's why we didn't want to be too restrictive right now.
The current implementation will show the user the following error if the slippage goes wild (screenshot).