### PR TITLE
refactor: retry failing API calls on 500 error

### DIFF
--- a/src/allowance/tokenApproval.ts
+++ b/src/allowance/tokenApproval.ts
@@ -36,7 +36,7 @@ export const getTokenApproval = async (
   }
 
   const approved = await getApproved(signer, token.address, approvalAddress)
-  return approved.toString()
+  return approved.toFixed(0)
 }
 
 export const bulkGetTokenApproval = async (

--- a/src/allowance/tokenApproval.ts
+++ b/src/allowance/tokenApproval.ts
@@ -36,7 +36,7 @@ export const getTokenApproval = async (
   }
 
   const approved = await getApproved(signer, token.address, approvalAddress)
-  return approved.toFixed(0)
+  return approved.toString()
 }
 
 export const bulkGetTokenApproval = async (

--- a/src/connectors.ts
+++ b/src/connectors.ts
@@ -1,9 +1,10 @@
 import { providers } from 'ethers'
-import { getRandomNumber, ServerError } from '.'
 
 import { ChainId } from './types'
 import { FallbackProvider } from '@ethersproject/providers'
 import ConfigService from './services/ConfigService'
+import { getRandomNumber } from './helpers'
+import { ServerError } from './utils/errors'
 
 // cached providers
 const chainProviders: Record<number, providers.FallbackProvider[]> = {}

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -77,7 +77,7 @@ export const checkPackageUpdates = async (
   }
   try {
     const pkgName = packageName ?? name
-    const response = await serverRequest<Response>(
+    const response = await request<Response>(
       'https://registry.npmjs.org/${pkgName}/latest'
     )
     const data = await response.json()
@@ -134,7 +134,7 @@ export const convertQuoteToRoute = (step: Step): Route => {
   return route
 }
 
-export const serverRequest = async <T = Response>(
+export const request = async <T = Response>(
   url: string,
   options?: RequestInit,
   retries = 1
@@ -150,7 +150,7 @@ export const serverRequest = async <T = Response>(
   } catch (error) {
     if (retries > 0 && (error as HTTPError)?.status === 500) {
       await sleep(500)
-      return serverRequest<T>(url, options, retries - 1)
+      return request<T>(url, options, retries - 1)
     }
     throw error
   }

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -1,7 +1,6 @@
 import { ExternalProvider } from '@ethersproject/providers'
 import { LifiStep, Route, Step, Token } from '@lifi/types'
 import { HTTPError, ValidationError } from './utils/errors'
-import { parseBackendError } from './utils/parseError'
 import { sleep } from './utils/utils'
 import { name, version } from './version'
 

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -78,8 +78,7 @@ export const checkPackageUpdates = async (
   try {
     const pkgName = packageName ?? name
     const response = await request<Response>(
-      'https://registry.npmjs.org/${pkgName}/latest',
-      {}
+      'https://registry.npmjs.org/${pkgName}/latest'
     )
     const data = await response.json()
     const latestVersion = data.version
@@ -141,7 +140,7 @@ export const requestSettings = {
 
 export const request = async <T = Response>(
   url: string,
-  options: RequestInit,
+  options?: RequestInit,
   retries = requestSettings.retries
 ): Promise<T> => {
   try {

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -78,7 +78,8 @@ export const checkPackageUpdates = async (
   try {
     const pkgName = packageName ?? name
     const response = await request<Response>(
-      'https://registry.npmjs.org/${pkgName}/latest'
+      'https://registry.npmjs.org/${pkgName}/latest',
+      {}
     )
     const data = await response.json()
     const latestVersion = data.version
@@ -134,10 +135,14 @@ export const convertQuoteToRoute = (step: Step): Route => {
   return route
 }
 
+export const requestSettings = {
+  retries: 1,
+}
+
 export const request = async <T = Response>(
   url: string,
-  options?: RequestInit,
-  retries = 1
+  options: RequestInit,
+  retries = requestSettings.retries
 ): Promise<T> => {
   try {
     const response: Response = await fetch(url, options)

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -77,7 +77,7 @@ export const checkPackageUpdates = async (
   try {
     const pkgName = packageName ?? name
     const response = await (
-      await fetch(`https://registry.npmjs.org/${pkgName}/latest`)
+      await serverRequest(`https://registry.npmjs.org/${pkgName}/latest`)
     ).json()
     const latestVersion = response.version
     const currentVersion = packageVersion ?? version

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -141,7 +141,7 @@ export const serverRequest = async <T = Response>(
   retries = 1
 ): Promise<T> => {
   try {
-    const response: Response = await serverRequest(url, options)
+    const response: Response = await fetch(url, options)
     if (!response.ok) {
       throw new HTTPError(response)
     }
@@ -153,6 +153,6 @@ export const serverRequest = async <T = Response>(
       await sleep(500)
       return serverRequest<T>(url, options, retries - 1)
     }
-    throw await parseBackendError(error)
+    throw error
   }
 }

--- a/src/services/ApiService.ts
+++ b/src/services/ApiService.ts
@@ -29,7 +29,7 @@ import ConfigService from './ConfigService'
 const retryFetch = async (
   url: string,
   options: any,
-  retries = 3
+  retries = 1
 ): Promise<Response> => {
   try {
     const response = await fetch(url, options)

--- a/src/services/ApiService.ts
+++ b/src/services/ApiService.ts
@@ -27,13 +27,13 @@ import { parseBackendError } from '../utils/parseError'
 import { sleep } from '../utils/utils'
 import ConfigService from './ConfigService'
 
-const lifiFetch = async (
+const serverRequest = async (
   url: string,
   options: RequestInit,
   retries = 1
 ): Promise<Response> => {
   try {
-    const response = await fetch(url, options)
+    const response = await serverRequest(url, options)
     if (!response.ok) {
       throw new HTTPError(response)
     }
@@ -41,7 +41,7 @@ const lifiFetch = async (
   } catch (error) {
     if (retries > 0 && (error as HTTPError)?.status === 500) {
       await sleep(500)
-      return lifiFetch(url, options, retries - 1)
+      return serverRequest(url, options, retries - 1)
     }
     throw error
   }
@@ -68,7 +68,7 @@ const getPossibilities = async (
 
   // send request
   try {
-    const response = await lifiFetch(
+    const response = await serverRequest(
       `${config.apiUrl}/advanced/possibilities`,
       {
         method: 'POST',
@@ -101,7 +101,7 @@ const getToken = async (
 
   const config = ConfigService.getInstance().getConfig()
   try {
-    const response = await fetch(
+    const response = await serverRequest(
       `${config.apiUrl}/token?${new URLSearchParams({
         chain,
         token,
@@ -171,7 +171,7 @@ const getQuote = async (
   )
 
   try {
-    const response = await fetch(
+    const response = await serverRequest(
       `${config.apiUrl}/quote?${new URLSearchParams(
         request as unknown as Record<string, string>
       )}`,
@@ -238,14 +238,17 @@ const getContractCallQuote = async (
 
   // send request
   try {
-    const response = await fetch(`${config.apiUrl}/quote/contractCall`, {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-      },
-      body: JSON.stringify(request),
-      signal: options?.signal,
-    })
+    const response = await serverRequest(
+      `${config.apiUrl}/quote/contractCall`,
+      {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify(request),
+        signal: options?.signal,
+      }
+    )
     if (!response.ok) {
       throw new HTTPError(response)
     }
@@ -280,7 +283,7 @@ const getStatus = async (
 
   const config = ConfigService.getInstance().getConfig()
   try {
-    const response = await fetch(
+    const response = await serverRequest(
       `${config.apiUrl}/status?${new URLSearchParams({
         bridge,
         fromChain,
@@ -307,7 +310,7 @@ const getChains = async (
   const config = ConfigService.getInstance().getConfig()
 
   try {
-    const response = await fetch(`${config.apiUrl}/chains`, {
+    const response = await serverRequest(`${config.apiUrl}/chains`, {
       signal: options?.signal,
     })
     if (!response.ok) {
@@ -338,7 +341,7 @@ const getRoutes = async (
 
   // send request
   try {
-    const response = await fetch(`${config.apiUrl}/advanced/routes`, {
+    const response = await serverRequest(`${config.apiUrl}/advanced/routes`, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
@@ -368,14 +371,17 @@ const getStepTransaction = async (
 
   const config = ConfigService.getInstance().getConfig()
   try {
-    const response = await fetch(`${config.apiUrl}/advanced/stepTransaction`, {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-      },
-      body: JSON.stringify(step),
-      signal: options?.signal,
-    })
+    const response = await serverRequest(
+      `${config.apiUrl}/advanced/stepTransaction`,
+      {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify(step),
+        signal: options?.signal,
+      }
+    )
     if (!response.ok) {
       throw new HTTPError(response)
     }
@@ -398,7 +404,7 @@ const getTools = async (
         delete request[key as keyof ToolsRequest]
     )
   }
-  const response = await fetch(
+  const response = await serverRequest(
     `${config.apiUrl}/tools?${new URLSearchParams(
       request as Record<string, string>
     )}`,
@@ -425,7 +431,7 @@ const getTokens = async (
         delete request[key as keyof TokensRequest]
     )
   }
-  const response = await fetch(
+  const response = await serverRequest(
     `${config.apiUrl}/tokens?${new URLSearchParams(
       request as Record<string, string>
     )}`,
@@ -452,3 +458,5 @@ export default {
   getTools,
   getTokens,
 }
+
+// create a wrapper function for fetch that prints response with a short and descriptive name not fetch

--- a/src/services/ApiService.ts
+++ b/src/services/ApiService.ts
@@ -24,6 +24,7 @@ import {
 } from '../types'
 import { HTTPError, ValidationError } from '../utils/errors'
 import { parseBackendError } from '../utils/parseError'
+import { sleep } from '../utils/utils'
 import ConfigService from './ConfigService'
 
 const retryFetch = async (
@@ -39,6 +40,7 @@ const retryFetch = async (
     return response
   } catch (error) {
     if (retries > 0 && (error as HTTPError)?.status === 500) {
+      await sleep(500)
       return retryFetch(url, options, retries - 1)
     }
     throw error

--- a/src/services/ApiService.ts
+++ b/src/services/ApiService.ts
@@ -6,7 +6,7 @@ import {
   TokensRequest,
   TokensResponse,
 } from '@lifi/types'
-import { serverRequest } from '../helpers'
+import { request } from '../helpers'
 import { isRoutesRequest, isStep } from '../typeguards'
 import {
   ChainId,
@@ -28,34 +28,35 @@ import { parseBackendError } from '../utils/parseError'
 import ConfigService from './ConfigService'
 
 const getPossibilities = async (
-  request?: PossibilitiesRequest,
+  requestConfig?: PossibilitiesRequest,
   options?: RequestOptions
 ): Promise<PossibilitiesResponse> => {
-  if (!request) {
-    request = {}
+  if (!requestConfig) {
+    requestConfig = {}
   }
 
   const config = ConfigService.getInstance().getConfig()
 
   // apply defaults
-  if (request.bridges || config.defaultRouteOptions.bridges) {
-    request.bridges = request.bridges || config.defaultRouteOptions.bridges
+  if (requestConfig.bridges || config.defaultRouteOptions.bridges) {
+    requestConfig.bridges =
+      requestConfig.bridges || config.defaultRouteOptions.bridges
   }
-  if (request.exchanges || config.defaultRouteOptions.exchanges) {
-    request.exchanges =
-      request.exchanges || config.defaultRouteOptions.exchanges
+  if (requestConfig.exchanges || config.defaultRouteOptions.exchanges) {
+    requestConfig.exchanges =
+      requestConfig.exchanges || config.defaultRouteOptions.exchanges
   }
 
   // send request
   try {
-    const response = await serverRequest<PossibilitiesResponse>(
+    const response = await request<PossibilitiesResponse>(
       `${config.apiUrl}/advanced/possibilities`,
       {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
         },
-        body: JSON.stringify(request),
+        body: JSON.stringify(requestConfig),
         signal: options?.signal,
       }
     )
@@ -80,7 +81,7 @@ const getToken = async (
 
   const config = ConfigService.getInstance().getConfig()
   try {
-    const response = await serverRequest<Token>(
+    const response = await request<Token>(
       `${config.apiUrl}/token?${new URLSearchParams({
         chain,
         token,
@@ -97,7 +98,7 @@ const getToken = async (
 }
 
 const getQuote = async (
-  request: QuoteRequest,
+  requestConfig: QuoteRequest,
   options?: RequestOptions
 ): Promise<Step> => {
   const config = ConfigService.getInstance().getConfig()
@@ -112,7 +113,7 @@ const getQuote = async (
     'toToken',
   ]
   requiredParameters.forEach((requiredParameter) => {
-    if (!request[requiredParameter]) {
+    if (!requestConfig[requiredParameter]) {
       throw new ValidationError(
         `Required parameter "${requiredParameter}" is missing.`
       )
@@ -120,36 +121,39 @@ const getQuote = async (
   })
 
   // apply defaults
-  request.order = request.order || config.defaultRouteOptions.order
-  request.slippage = request.slippage || config.defaultRouteOptions.slippage
-  request.integrator =
-    request.integrator || config.defaultRouteOptions.integrator
-  request.referrer = request.referrer || config.defaultRouteOptions.referrer
-  request.fee = request.fee || config.defaultRouteOptions.fee
+  requestConfig.order = requestConfig.order || config.defaultRouteOptions.order
+  requestConfig.slippage =
+    requestConfig.slippage || config.defaultRouteOptions.slippage
+  requestConfig.integrator =
+    requestConfig.integrator || config.defaultRouteOptions.integrator
+  requestConfig.referrer =
+    requestConfig.referrer || config.defaultRouteOptions.referrer
+  requestConfig.fee = requestConfig.fee || config.defaultRouteOptions.fee
 
-  request.allowBridges =
-    request.allowBridges || config.defaultRouteOptions.bridges?.allow
-  request.denyBridges =
-    request.denyBridges || config.defaultRouteOptions.bridges?.deny
-  request.preferBridges =
-    request.preferBridges || config.defaultRouteOptions.bridges?.prefer
-  request.allowExchanges =
-    request.allowExchanges || config.defaultRouteOptions.exchanges?.allow
-  request.denyExchanges =
-    request.denyExchanges || config.defaultRouteOptions.exchanges?.deny
-  request.preferExchanges =
-    request.preferExchanges || config.defaultRouteOptions.exchanges?.prefer
+  requestConfig.allowBridges =
+    requestConfig.allowBridges || config.defaultRouteOptions.bridges?.allow
+  requestConfig.denyBridges =
+    requestConfig.denyBridges || config.defaultRouteOptions.bridges?.deny
+  requestConfig.preferBridges =
+    requestConfig.preferBridges || config.defaultRouteOptions.bridges?.prefer
+  requestConfig.allowExchanges =
+    requestConfig.allowExchanges || config.defaultRouteOptions.exchanges?.allow
+  requestConfig.denyExchanges =
+    requestConfig.denyExchanges || config.defaultRouteOptions.exchanges?.deny
+  requestConfig.preferExchanges =
+    requestConfig.preferExchanges ||
+    config.defaultRouteOptions.exchanges?.prefer
 
-  Object.keys(request).forEach(
+  Object.keys(requestConfig).forEach(
     (key) =>
-      !request[key as keyof QuoteRequest] &&
-      delete request[key as keyof QuoteRequest]
+      !requestConfig[key as keyof QuoteRequest] &&
+      delete requestConfig[key as keyof QuoteRequest]
   )
 
   try {
-    const response = await serverRequest<Step>(
+    const response = await request<Step>(
       `${config.apiUrl}/quote?${new URLSearchParams(
-        request as unknown as Record<string, string>
+        requestConfig as unknown as Record<string, string>
       )}`,
       {
         signal: options?.signal,
@@ -163,7 +167,7 @@ const getQuote = async (
 }
 
 const getContractCallQuote = async (
-  request: ContractCallQuoteRequest,
+  requestConfig: ContractCallQuoteRequest,
   options?: RequestOptions
 ): Promise<Step> => {
   const config = ConfigService.getInstance().getConfig()
@@ -181,7 +185,7 @@ const getContractCallQuote = async (
     'toContractGasLimit',
   ]
   requiredParameters.forEach((requiredParameter) => {
-    if (!request[requiredParameter]) {
+    if (!requestConfig[requiredParameter]) {
       throw new ValidationError(
         `Required parameter "${requiredParameter}" is missing.`
       )
@@ -190,35 +194,38 @@ const getContractCallQuote = async (
 
   // apply defaults
   // option.order is not used in this endpoint
-  request.slippage = request.slippage || config.defaultRouteOptions.slippage
-  request.integrator =
-    request.integrator || config.defaultRouteOptions.integrator
-  request.referrer = request.referrer || config.defaultRouteOptions.referrer
-  request.fee = request.fee || config.defaultRouteOptions.fee
+  requestConfig.slippage =
+    requestConfig.slippage || config.defaultRouteOptions.slippage
+  requestConfig.integrator =
+    requestConfig.integrator || config.defaultRouteOptions.integrator
+  requestConfig.referrer =
+    requestConfig.referrer || config.defaultRouteOptions.referrer
+  requestConfig.fee = requestConfig.fee || config.defaultRouteOptions.fee
 
-  request.allowBridges =
-    request.allowBridges || config.defaultRouteOptions.bridges?.allow
-  request.denyBridges =
-    request.denyBridges || config.defaultRouteOptions.bridges?.deny
-  request.preferBridges =
-    request.preferBridges || config.defaultRouteOptions.bridges?.prefer
-  request.allowExchanges =
-    request.allowExchanges || config.defaultRouteOptions.exchanges?.allow
-  request.denyExchanges =
-    request.denyExchanges || config.defaultRouteOptions.exchanges?.deny
-  request.preferExchanges =
-    request.preferExchanges || config.defaultRouteOptions.exchanges?.prefer
+  requestConfig.allowBridges =
+    requestConfig.allowBridges || config.defaultRouteOptions.bridges?.allow
+  requestConfig.denyBridges =
+    requestConfig.denyBridges || config.defaultRouteOptions.bridges?.deny
+  requestConfig.preferBridges =
+    requestConfig.preferBridges || config.defaultRouteOptions.bridges?.prefer
+  requestConfig.allowExchanges =
+    requestConfig.allowExchanges || config.defaultRouteOptions.exchanges?.allow
+  requestConfig.denyExchanges =
+    requestConfig.denyExchanges || config.defaultRouteOptions.exchanges?.deny
+  requestConfig.preferExchanges =
+    requestConfig.preferExchanges ||
+    config.defaultRouteOptions.exchanges?.prefer
 
   // send request
   try {
-    const response = await serverRequest<Step>(
+    const response = await request<Step>(
       `${config.apiUrl}/quote/contractCall`,
       {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
         },
-        body: JSON.stringify(request),
+        body: JSON.stringify(requestConfig),
         signal: options?.signal,
       }
     )
@@ -253,7 +260,7 @@ const getStatus = async (
 
   const config = ConfigService.getInstance().getConfig()
   try {
-    const response = await serverRequest<StatusResponse>(
+    const response = await request<StatusResponse>(
       `${config.apiUrl}/status?${new URLSearchParams({
         bridge,
         fromChain,
@@ -277,12 +284,9 @@ const getChains = async (
   const config = ConfigService.getInstance().getConfig()
 
   try {
-    const response = await serverRequest<ChainsResponse>(
-      `${config.apiUrl}/chains`,
-      {
-        signal: options?.signal,
-      }
-    )
+    const response = await request<ChainsResponse>(`${config.apiUrl}/chains`, {
+      signal: options?.signal,
+    })
 
     return response.chains
   } catch (e) {
@@ -291,31 +295,31 @@ const getChains = async (
 }
 
 const getRoutes = async (
-  request: RoutesRequest,
+  requestConfig: RoutesRequest,
   options?: RequestOptions
 ): Promise<RoutesResponse> => {
-  if (!isRoutesRequest(request)) {
+  if (!isRoutesRequest(requestConfig)) {
     throw new ValidationError('Invalid routes request.')
   }
 
   const config = ConfigService.getInstance().getConfig()
 
   // apply defaults
-  request.options = {
+  requestConfig.options = {
     ...config.defaultRouteOptions,
-    ...request.options,
+    ...requestConfig.options,
   }
 
   // send request
   try {
-    const response = await serverRequest<RoutesResponse>(
+    const response = await request<RoutesResponse>(
       `${config.apiUrl}/advanced/routes`,
       {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
         },
-        body: JSON.stringify(request),
+        body: JSON.stringify(requestConfig),
         signal: options?.signal,
       }
     )
@@ -338,7 +342,7 @@ const getStepTransaction = async (
 
   const config = ConfigService.getInstance().getConfig()
   try {
-    const response = await serverRequest<Step>(
+    const response = await request<Step>(
       `${config.apiUrl}/advanced/stepTransaction`,
       {
         method: 'POST',
@@ -357,20 +361,20 @@ const getStepTransaction = async (
 }
 
 const getTools = async (
-  request?: ToolsRequest,
+  requestConfig?: ToolsRequest,
   options?: RequestOptions
 ): Promise<ToolsResponse> => {
   const config = ConfigService.getInstance().getConfig()
-  if (request) {
-    Object.keys(request).forEach(
+  if (requestConfig) {
+    Object.keys(requestConfig).forEach(
       (key) =>
-        !request[key as keyof ToolsRequest] &&
-        delete request[key as keyof ToolsRequest]
+        !requestConfig[key as keyof ToolsRequest] &&
+        delete requestConfig[key as keyof ToolsRequest]
     )
   }
-  const response = await serverRequest<ToolsResponse>(
+  const response = await request<ToolsResponse>(
     `${config.apiUrl}/tools?${new URLSearchParams(
-      request as Record<string, string>
+      requestConfig as Record<string, string>
     )}`,
     {
       signal: options?.signal,
@@ -381,20 +385,20 @@ const getTools = async (
 }
 
 const getTokens = async (
-  request?: TokensRequest,
+  requestConfig?: TokensRequest,
   options?: RequestOptions
 ): Promise<TokensResponse> => {
   const config = ConfigService.getInstance().getConfig()
-  if (request) {
-    Object.keys(request).forEach(
+  if (requestConfig) {
+    Object.keys(requestConfig).forEach(
       (key) =>
-        !request[key as keyof TokensRequest] &&
-        delete request[key as keyof TokensRequest]
+        !requestConfig[key as keyof TokensRequest] &&
+        delete requestConfig[key as keyof TokensRequest]
     )
   }
-  const response = await serverRequest<TokensResponse>(
+  const response = await request<TokensResponse>(
     `${config.apiUrl}/tokens?${new URLSearchParams(
-      request as Record<string, string>
+      requestConfig as Record<string, string>
     )}`,
     {
       signal: options?.signal,

--- a/src/services/ApiService.ts
+++ b/src/services/ApiService.ts
@@ -416,5 +416,3 @@ export default {
   getTools,
   getTokens,
 }
-
-// create a wrapper function for fetch that prints response with a short and descriptive name not fetch

--- a/src/services/ApiService.ts
+++ b/src/services/ApiService.ts
@@ -27,7 +27,7 @@ import { parseBackendError } from '../utils/parseError'
 import { sleep } from '../utils/utils'
 import ConfigService from './ConfigService'
 
-const retryFetch = async (
+const lifiFetch = async (
   url: string,
   options: RequestInit,
   retries = 1
@@ -41,7 +41,7 @@ const retryFetch = async (
   } catch (error) {
     if (retries > 0 && (error as HTTPError)?.status === 500) {
       await sleep(500)
-      return retryFetch(url, options, retries - 1)
+      return lifiFetch(url, options, retries - 1)
     }
     throw error
   }
@@ -68,7 +68,7 @@ const getPossibilities = async (
 
   // send request
   try {
-    const response = await retryFetch(
+    const response = await lifiFetch(
       `${config.apiUrl}/advanced/possibilities`,
       {
         method: 'POST',

--- a/src/services/ApiService.ts
+++ b/src/services/ApiService.ts
@@ -28,7 +28,7 @@ import ConfigService from './ConfigService'
 
 const retryFetch = async (
   url: string,
-  options: any,
+  options: RequestInit,
   retries = 1
 ): Promise<Response> => {
   try {
@@ -37,11 +37,11 @@ const retryFetch = async (
       throw new HTTPError(response)
     }
     return response
-  } catch (e) {
-    if (retries > 0) {
+  } catch (error) {
+    if (retries > 0 && (error as HTTPError)?.status === 500) {
       return retryFetch(url, options, retries - 1)
     }
-    throw e
+    throw error
   }
 }
 

--- a/src/services/ApiService.unit.spec.ts
+++ b/src/services/ApiService.unit.spec.ts
@@ -21,6 +21,7 @@ import {
   it,
   vi,
 } from 'vitest'
+import { requestSettings } from '../helpers'
 import { ServerError, SlippageError, ValidationError } from '../utils/errors'
 import ApiService from './ApiService'
 import { handlers } from './ApiService.unit.handlers'
@@ -35,13 +36,17 @@ describe('ApiService', () => {
     server.listen({
       onUnhandledRequest: 'warn',
     })
+    requestSettings.retries = 0
     // server.use(...handlers)
   })
   beforeEach(() => {
     vi.clearAllMocks()
   })
   afterEach(() => server.resetHandlers())
-  afterAll(() => server.close())
+  afterAll(() => {
+    requestSettings.retries = 1
+    server.close()
+  })
 
   describe('getRoutes', () => {
     const getRoutesRequest = ({
@@ -140,7 +145,7 @@ describe('ApiService', () => {
           await expect(ApiService.getRoutes(request)).rejects.toThrowError(
             new ServerError('Oops')
           )
-          expect(mockedFetch).toHaveBeenCalledTimes(2)
+          expect(mockedFetch).toHaveBeenCalledTimes(1)
         })
       })
 
@@ -169,7 +174,7 @@ describe('ApiService', () => {
           await expect(ApiService.getPossibilities()).rejects.toThrowError(
             new ServerError('Oops')
           )
-          expect(mockedFetch).toHaveBeenCalledTimes(2)
+          expect(mockedFetch).toHaveBeenCalledTimes(1)
         })
       })
 
@@ -238,7 +243,7 @@ describe('ApiService', () => {
           await expect(
             ApiService.getToken(ChainId.DAI, 'DAI')
           ).rejects.toThrowError(new ServerError('Oops'))
-          expect(mockedFetch).toHaveBeenCalledTimes(2)
+          expect(mockedFetch).toHaveBeenCalledTimes(1)
         })
       })
 
@@ -363,7 +368,7 @@ describe('ApiService', () => {
               toToken,
             })
           ).rejects.toThrowError(new ServerError('Oops'))
-          expect(mockedFetch).toHaveBeenCalledTimes(2)
+          expect(mockedFetch).toHaveBeenCalledTimes(1)
         })
       })
 
@@ -454,7 +459,7 @@ describe('ApiService', () => {
           await expect(
             ApiService.getStatus({ bridge, fromChain, toChain, txHash })
           ).rejects.toThrowError(new ServerError('Oops'))
-          expect(mockedFetch).toHaveBeenCalledTimes(2)
+          expect(mockedFetch).toHaveBeenCalledTimes(1)
         })
       })
 
@@ -480,7 +485,7 @@ describe('ApiService', () => {
         await expect(ApiService.getChains()).rejects.toThrowError(
           new ServerError('Oops')
         )
-        expect(mockedFetch).toHaveBeenCalledTimes(2)
+        expect(mockedFetch).toHaveBeenCalledTimes(1)
       })
     })
 
@@ -651,7 +656,7 @@ describe('ApiService', () => {
             await expect(
               ApiService.getStepTransaction(step)
             ).rejects.toThrowError(new ServerError('Oops'))
-            expect(mockedFetch).toHaveBeenCalledTimes(2)
+            expect(mockedFetch).toHaveBeenCalledTimes(1)
           })
         })
 

--- a/src/services/ApiService.unit.spec.ts
+++ b/src/services/ApiService.unit.spec.ts
@@ -140,7 +140,7 @@ describe('ApiService', () => {
           await expect(ApiService.getRoutes(request)).rejects.toThrowError(
             new ServerError('Oops')
           )
-          expect(mockedFetch).toHaveBeenCalledTimes(1)
+          expect(mockedFetch).toHaveBeenCalledTimes(2)
         })
       })
 
@@ -238,7 +238,7 @@ describe('ApiService', () => {
           await expect(
             ApiService.getToken(ChainId.DAI, 'DAI')
           ).rejects.toThrowError(new ServerError('Oops'))
-          expect(mockedFetch).toHaveBeenCalledTimes(1)
+          expect(mockedFetch).toHaveBeenCalledTimes(2)
         })
       })
 
@@ -363,7 +363,7 @@ describe('ApiService', () => {
               toToken,
             })
           ).rejects.toThrowError(new ServerError('Oops'))
-          expect(mockedFetch).toHaveBeenCalledTimes(1)
+          expect(mockedFetch).toHaveBeenCalledTimes(2)
         })
       })
 
@@ -454,7 +454,7 @@ describe('ApiService', () => {
           await expect(
             ApiService.getStatus({ bridge, fromChain, toChain, txHash })
           ).rejects.toThrowError(new ServerError('Oops'))
-          expect(mockedFetch).toHaveBeenCalledTimes(1)
+          expect(mockedFetch).toHaveBeenCalledTimes(2)
         })
       })
 
@@ -480,7 +480,7 @@ describe('ApiService', () => {
         await expect(ApiService.getChains()).rejects.toThrowError(
           new ServerError('Oops')
         )
-        expect(mockedFetch).toHaveBeenCalledTimes(1)
+        expect(mockedFetch).toHaveBeenCalledTimes(2)
       })
     })
 
@@ -651,7 +651,7 @@ describe('ApiService', () => {
             await expect(
               ApiService.getStepTransaction(step)
             ).rejects.toThrowError(new ServerError('Oops'))
-            expect(mockedFetch).toHaveBeenCalledTimes(1)
+            expect(mockedFetch).toHaveBeenCalledTimes(2)
           })
         })
 

--- a/src/services/ApiService.unit.spec.ts
+++ b/src/services/ApiService.unit.spec.ts
@@ -173,7 +173,7 @@ describe('ApiService', () => {
         })
       })
 
-      describe('and the backend call fails with 429', () => {
+      describe('and the backend call fails with 409', () => {
         it('throw a the error without retrying', async () => {
           server.use(
             rest.post(

--- a/src/services/ApiService.unit.spec.ts
+++ b/src/services/ApiService.unit.spec.ts
@@ -162,6 +162,14 @@ describe('ApiService', () => {
   describe('getPossibilities', () => {
     describe('user input is valid', () => {
       describe('and the backend call fails with 500', () => {
+        beforeEach(() => {
+          requestSettings.retries = 1
+        })
+
+        afterEach(() => {
+          requestSettings.retries = 0
+        })
+
         it('throw a the error after retrying once', async () => {
           server.use(
             rest.post(
@@ -174,7 +182,7 @@ describe('ApiService', () => {
           await expect(ApiService.getPossibilities()).rejects.toThrowError(
             new ServerError('Oops')
           )
-          expect(mockedFetch).toHaveBeenCalledTimes(1)
+          expect(mockedFetch).toHaveBeenCalledTimes(2)
         })
       })
 

--- a/src/utils/errors.ts
+++ b/src/utils/errors.ts
@@ -201,6 +201,6 @@ export class HTTPError extends Error {
 
     this.name = 'HTTPError'
     this.response = response
-    this.status = response.code
+    this.status = response.status
   }
 }

--- a/src/utils/errors.ts
+++ b/src/utils/errors.ts
@@ -189,6 +189,7 @@ export class UnknownError extends LifiError {
 
 export class HTTPError extends Error {
   public response: Response
+  public status: number
 
   constructor(response: Response) {
     const code = response.status || response.status === 0 ? response.status : ''
@@ -200,5 +201,6 @@ export class HTTPError extends Error {
 
     this.name = 'HTTPError'
     this.response = response
+    this.status = response.status
   }
 }

--- a/src/utils/errors.ts
+++ b/src/utils/errors.ts
@@ -201,6 +201,6 @@ export class HTTPError extends Error {
 
     this.name = 'HTTPError'
     this.response = response
-    this.status = response.status
+    this.status = response.code
   }
 }


### PR DESCRIPTION
Adding a 1 retry policy for API calls with 500 error code