### PR TITLE
Return large numbers as string

### DIFF
--- a/src/allowance/tokenApproval.ts
+++ b/src/allowance/tokenApproval.ts
@@ -36,7 +36,7 @@ export const getTokenApproval = async (
   }
 
   const approved = await getApproved(signer, token.address, approvalAddress)
-  return approved.toString()
+  return approved.toFixed(0)
 }
 
 export const bulkGetTokenApproval = async (


### PR DESCRIPTION
Previously, Large numbers were being returned in scientific format

Expected: Large values should also be returned as integer string