### PR TITLE
Remove references of getChainById exposed by types package

### DIFF
--- a/src/execution/ExecutionManager.ts
+++ b/src/execution/ExecutionManager.ts
@@ -232,11 +232,16 @@ export class ExecutionManager {
         gasUsed: statusResponse.sending.gasUsed,
       })
     } catch (e: unknown) {
+      const htmlMessage = await getTransactionFailedMessage(
+        step,
+        process.txLink
+      )
+
       process = statusManager.updateProcess(step, process.type, 'FAILED', {
         error: {
           code: LifiErrorCode.TransactionFailed,
           message: 'Failed while waiting for receiving chain.',
-          htmlMessage: getTransactionFailedMessage(step, process.txLink),
+          htmlMessage,
         },
       })
       statusManager.updateExecution(step, 'FAILED')

--- a/src/services/ConfigService.unit.spec.ts
+++ b/src/services/ConfigService.unit.spec.ts
@@ -1,8 +1,10 @@
 import { beforeEach, describe, expect, it } from 'vitest'
 import { ChainId, getChainById, supportedChains } from '../types'
+import ChainsService from './ChainsService'
 import ConfigService from './ConfigService'
 
 let configService: ConfigService
+let chainsService: ChainsService
 
 describe('ConfigService', () => {
   beforeEach(() => {
@@ -120,7 +122,7 @@ describe('ConfigService', () => {
   })
 
   describe('updateChains', () => {
-    it('should set rpcs/multicall address', () => {
+    it('should set rpcs/multicall address', async () => {
       const config = configService.updateChains(supportedChains)
       for (const chainId of Object.values(ChainId)) {
         // This is a workaround until we complete the transition to
@@ -128,7 +130,7 @@ describe('ConfigService', () => {
         try {
           // This will fail with SOL, SOLT, TER, TERT, OAS, OAST
           // as getChainById(ChainId) returns EVMChain
-          getChainById(Number(chainId))
+          chainsService.getChainById(chainId as ChainId)
         } catch {
           continue
         }

--- a/src/utils/parseError.ts
+++ b/src/utils/parseError.ts
@@ -81,14 +81,15 @@ export const getTransactionNotSentMessage = async (
   return transactionNotSend
 }
 
-export const getTransactionFailedMessage = (
+export const getTransactionFailedMessage = async (
   step: Step,
   txLink?: string
-): string => {
+): Promise<string> => {
+  const chainsService = ChainsService.getInstance()
+  const chainName = await chainsService.getChainById(step.action.toChainId)
+
   const baseString = `It appears that your transaction may not have been successful.
-  However, to confirm this, please check your ${
-    getChainById(step.action.toChainId).name
-  } wallet for ${step.action.toToken.symbol}.`
+  However, to confirm this, please check your ${chainName.name} wallet for ${step.action.toToken.symbol}.`
   return txLink
     ? `${baseString}
     You can also check the&nbsp;<a href="${txLink}" target="_blank" rel="nofollow noreferrer">block explorer</a> for more information.`

--- a/src/utils/parseError.ts
+++ b/src/utils/parseError.ts
@@ -86,10 +86,10 @@ export const getTransactionFailedMessage = async (
   txLink?: string
 ): Promise<string> => {
   const chainsService = ChainsService.getInstance()
-  const chainName = await chainsService.getChainById(step.action.toChainId)
+  const chain = await chainsService.getChainById(step.action.toChainId)
 
   const baseString = `It appears that your transaction may not have been successful.
-  However, to confirm this, please check your ${chainName.name} wallet for ${step.action.toToken.symbol}.`
+  However, to confirm this, please check your ${chain.name} wallet for ${step.action.toToken.symbol}.`
   return txLink
     ? `${baseString}
     You can also check the&nbsp;<a href="${txLink}" target="_blank" rel="nofollow noreferrer">block explorer</a> for more information.`


### PR DESCRIPTION
Replacing all references of `getChainById` exposed by types package with instance of `ChainService.getChainById`.

LF-1186