### PR TITLE
fix: storing the timestamp of wallet approvals

### DIFF
--- a/src/allowance/checkAllowance.ts
+++ b/src/allowance/checkAllowance.ts
@@ -39,6 +39,12 @@ export const checkAllowance = async (
         'DONE'
       )
     } else {
+      allowanceProcess = statusManager.updateProcess(
+        step,
+        allowanceProcess.type,
+        'ACTION_REQUIRED'
+      )
+
       const approved = await getApproved(
         signer,
         step.action.fromToken.address,

--- a/src/execution/StatusManager.ts
+++ b/src/execution/StatusManager.ts
@@ -170,19 +170,23 @@ export class StatusManager {
     switch (status) {
       case 'CANCELLED':
         currentProcess.doneAt = Date.now()
+        step.execution.pauseTimestamp = null
         break
       case 'FAILED':
         currentProcess.doneAt = Date.now()
         step.execution.status = 'FAILED'
+        step.execution.pauseTimestamp = null
         break
       case 'DONE':
         currentProcess.doneAt = Date.now()
+        step.execution.pauseTimestamp = null
         break
       case 'PENDING':
         step.execution.status = 'PENDING'
         break
       case 'ACTION_REQUIRED':
         step.execution.status = 'ACTION_REQUIRED'
+        step.execution.pauseTimestamp = Date.now()
         break
       default:
         break

--- a/src/execution/StatusManager.ts
+++ b/src/execution/StatusManager.ts
@@ -170,23 +170,23 @@ export class StatusManager {
     switch (status) {
       case 'CANCELLED':
         currentProcess.doneAt = Date.now()
-        step.execution.pauseTimestamp = null
         break
       case 'FAILED':
         currentProcess.doneAt = Date.now()
         step.execution.status = 'FAILED'
-        step.execution.pauseTimestamp = null
         break
       case 'DONE':
         currentProcess.doneAt = Date.now()
-        step.execution.pauseTimestamp = null
         break
       case 'PENDING':
+        if (step.execution.status === 'ACTION_REQUIRED') {
+          // the start of eoa confirmation process can be marked by the startAt of process
+          currentProcess.eoaConfirmationAt = Date.now()
+        }
         step.execution.status = 'PENDING'
         break
       case 'ACTION_REQUIRED':
         step.execution.status = 'ACTION_REQUIRED'
-        step.execution.pauseTimestamp = Date.now()
         break
       default:
         break

--- a/src/execution/StatusManager.ts
+++ b/src/execution/StatusManager.ts
@@ -181,7 +181,7 @@ export class StatusManager {
       case 'PENDING':
         if (step.execution.status === 'ACTION_REQUIRED') {
           // the start of eoa confirmation process can be marked by the startAt of process
-          currentProcess.eoaConfirmationAt = Date.now()
+          currentProcess.approvedAt = Date.now()
         }
         step.execution.status = 'PENDING'
         break


### PR DESCRIPTION
# Issue

There are process involving external user authorisation and the time spent in approval of those requests shouldn't be considered in the Swap/Bridge estimated time.

# Fix

Calculate the estimated pending time after omitting time taken for external approvals.

SDK will now hold the timestamp ( `approvedAt` ) at which the user approved the request

For a process involving the External action:

- `startAt` is the time in which the wallet confirmation/signature is triggered
- `approvedAt` is the time when the user approved the request

By accounting this, we can have an accurate countdown for the entire swap/bridge.