### PR TITLE
feat: adding getConnections endpoint to SDK

### DIFF
--- a/src/LiFi.ts
+++ b/src/LiFi.ts
@@ -3,6 +3,8 @@ import { FallbackProvider } from '@ethersproject/providers'
 import {
   ChainId,
   ChainKey,
+  ConnectionsRequest,
+  ConnectionsResponse,
   ContractCallQuoteRequest,
   ExtendedChain,
   GasRecommendationRequest,
@@ -348,4 +350,20 @@ export class LiFi extends RouteExecutionManager {
   revokeTokenApproval = (request: RevokeApprovalRequest): Promise<void> => {
     return revokeTokenApproval(request)
   }
+}
+
+/**
+ * Get all the available connections for swap/bridging tokens
+ * @param connectionRequest ConnectionsRequest
+ * @returns ConnectionsResponse
+ */
+
+export const getConnections = async (
+  connectionRequest: ConnectionsRequest
+): Promise<ConnectionsResponse> => {
+  const connections = await ApiService.getAvailableConnections(
+    connectionRequest
+  )
+
+  return connections
 }

--- a/src/services/ApiService.ts
+++ b/src/services/ApiService.ts
@@ -1,4 +1,6 @@
 import {
+  ConnectionsRequest,
+  ConnectionsResponse,
   ContractCallQuoteRequest,
   GasRecommendationRequest,
   GasRecommendationResponse,
@@ -438,6 +440,43 @@ const getGasRecommendation = async (
   }
 }
 
+const getAvailableConnections = async (
+  connectionRequest: ConnectionsRequest
+): Promise<ConnectionsResponse> => {
+  const config = ConfigService.getInstance().getConfig()
+
+  const url = new URL(`${config.apiUrl}/connections`)
+
+  const { fromChain, fromToken, toChain, toToken, allowBridges } =
+    connectionRequest
+
+  if (fromChain) {
+    url.searchParams.append('fromChain', fromChain as unknown as string)
+  }
+  if (fromToken) {
+    url.searchParams.append('fromToken', fromToken)
+  }
+  if (toChain) {
+    url.searchParams.append('fromToken', toChain as unknown as string)
+  }
+  if (toToken) {
+    url.searchParams.append('fromToken', toToken)
+  }
+
+  if (allowBridges?.length) {
+    allowBridges.forEach((bridge) => {
+      url.searchParams.append('allowBridges', bridge)
+    })
+  }
+
+  try {
+    const response = await request<ConnectionsResponse>(url)
+    return response
+  } catch (e) {
+    throw await parseBackendError(e)
+  }
+}
+
 export default {
   getChains,
   getContractCallQuote,
@@ -450,4 +489,5 @@ export default {
   getToken,
   getTokens,
   getTools,
+  getAvailableConnections,
 }

--- a/src/services/ApiService.unit.spec.ts
+++ b/src/services/ApiService.unit.spec.ts
@@ -2,6 +2,7 @@ import {
   Action,
   ChainId,
   CoinKey,
+  ConnectionsRequest,
   Estimate,
   findDefaultToken,
   RoutesRequest,
@@ -723,6 +724,36 @@ describe('ApiService', () => {
           expect(mockedFetch).toHaveBeenCalledTimes(1)
         })
       })
+    })
+  })
+  describe('getAvailableConnections', () => {
+    it('returns empty array in response', async () => {
+      server.use(
+        rest.get(`${config.apiUrl}/connections`, async (_, response, context) =>
+          response(context.status(200), context.json({ connections: [] }))
+        )
+      )
+
+      const connectionRequest: ConnectionsRequest = {
+        fromChain: ChainId.BSC,
+        toChain: ChainId.OPT,
+        fromToken: findDefaultToken(CoinKey.USDC, ChainId.BSC).address,
+        toToken: findDefaultToken(CoinKey.USDC, ChainId.OPT).address,
+        allowBridges: ['connext', 'uniswap', 'polygon'],
+      }
+
+      const generatedURL =
+        // eslint-disable-next-line max-len
+        'https://li.quest/v1/connections?fromChain=56&fromToken=0x8ac76a51cc950d9822d68b83fe1ad97b32cd580d&fromToken=10&fromToken=0x7f5c764cbc14f9669b88837ca1490cca17c31607&allowBridges=connext&allowBridges=uniswap&allowBridges=polygon'
+
+      await expect(
+        ApiService.getAvailableConnections(connectionRequest)
+      ).resolves.toEqual({
+        connections: [],
+      })
+
+      expect((mockedFetch.mock.calls[0][0] as URL).href).toEqual(generatedURL)
+      expect(mockedFetch).toHaveBeenCalledOnce()
     })
   })
 })


### PR DESCRIPTION
# FEATURE

Add getConnections endpoint to SDK [LF-1232]

## TL;DR

This feature adds the ability to call the getConnections endpoint in the SDK.

## DESCRIPTION

This feature fulfills a user request found at https://github.com/lifinance/sdk/issues/87. It adds a new function to the SDK that allows developers to call the getConnections endpoint. This function returns all available connections based on the provided configuration.

## STEPS TO TEST

To test this feature, follow the steps below:

1. Initialize the SDK.
2. Call getConnections function to retrieve all available connections based on the configuration.
3. Verify that the function returns the expected results.

## EXPECTED RESULTS

The getConnections function should return all available connections based on the provided configuration.

## CHECKLIST

- [x] Performed a self-review of my code.
- [x] Added comments to the code for better readability.
- [x] Added tests that cover the new functionality.
- [x] Made sure that existing tests are still passing. 


[LF-1232]: https://lifi.atlassian.net/browse/LF-1232?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ