### PR TITLE
fix: don't trigger chain switch if all actions are done from source chain [LF-1131]

### DIFF
--- a/src/execution/StepExecutor.ts
+++ b/src/execution/StepExecutor.ts
@@ -55,10 +55,14 @@ export class StepExecutor {
   executeStep = async (signer: Signer, step: LifiStep): Promise<LifiStep> => {
     // Make sure that the chain is still correct
 
+    // Find if the step is waiting for a transaction on the receiving chain
     const recievingChainProcess = step.execution?.process.find(
       (process) => process.type === 'RECEIVING_CHAIN'
     )
 
+    // If the step is waiting for a transaction on the receiving chain, we do not switch the chain
+    // All changes are already done from the source chain
+    // Return the step
     if (recievingChainProcess?.substatus === 'WAIT_DESTINATION_TRANSACTION') {
       return step
     }

--- a/src/execution/StepExecutor.ts
+++ b/src/execution/StepExecutor.ts
@@ -54,6 +54,15 @@ export class StepExecutor {
 
   executeStep = async (signer: Signer, step: LifiStep): Promise<LifiStep> => {
     // Make sure that the chain is still correct
+
+    const recievingChainProcess = step.execution?.process.find(
+      (process) => process.type === 'RECEIVING_CHAIN'
+    )
+
+    if (recievingChainProcess?.substatus === 'WAIT_DESTINATION_TRANSACTION') {
+      return step
+    }
+
     const updatedSigner = await switchChain(
       signer,
       this.statusManager,

--- a/src/execution/StepExecutor.ts
+++ b/src/execution/StepExecutor.ts
@@ -55,7 +55,7 @@ export class StepExecutor {
   executeStep = async (signer: Signer, step: LifiStep): Promise<LifiStep> => {
     // Make sure that the chain is still correct
 
-    // Find if the step is waiting for a transaction on the receiving chain
+    // Find if it's bridging and the step is waiting for a transaction on the receiving chain
     const recievingChainProcess = step.execution?.process.find(
       (process) => process.type === 'RECEIVING_CHAIN'
     )
@@ -63,24 +63,25 @@ export class StepExecutor {
     // If the step is waiting for a transaction on the receiving chain, we do not switch the chain
     // All changes are already done from the source chain
     // Return the step
-    if (recievingChainProcess?.substatus === 'WAIT_DESTINATION_TRANSACTION') {
-      return step
+    if (
+      recievingChainProcess?.substatus !== 'WAIT_DESTINATION_TRANSACTION' ||
+      !recievingChainProcess
+    ) {
+      const updatedSigner = await switchChain(
+        signer,
+        this.statusManager,
+        step,
+        this.settings.switchChainHook,
+        this.allowUserInteraction
+      )
+
+      if (!updatedSigner) {
+        // Chain switch was not successful, stop execution here
+        return step
+      }
+
+      signer = updatedSigner
     }
-
-    const updatedSigner = await switchChain(
-      signer,
-      this.statusManager,
-      step,
-      this.settings.switchChainHook,
-      this.allowUserInteraction
-    )
-
-    if (!updatedSigner) {
-      // Chain switch was not successful, stop execution here
-      return step
-    }
-
-    signer = updatedSigner
 
     const parameters = {
       signer,


### PR DESCRIPTION
# FIX

Switching chains shouldn't be triggered if all actions are done from source chain [LF-1131]

## TL;DR
Disable chain switching if all required actions are already completed on the source chain.

## DESCRIPTION
Currently, the chain switching window is triggered even if all required actions are already completed on the source chain. This can be an unnecessary interruption for users who only need to wait for the tokens to be received in the receiving chain.

This feature will disable the chain switching window if all required actions are already completed on the source chain, and the user only needs to wait for the tokens to be received in the receiving chain.

## STEPS TO TEST
1. Bridge USDC from Ethereum to Polygon.
2. Switch your chains to a third network, say Binance.
3. Upon starting the process, the chain would be promptly switched to the source chain which is Ethereum.
4. Once the allowance is given and this transaction is signed, all the actions that are required from the source are completed, and now we will have to wait for the tokens to be deposited in the receiving chain.
5. While the screen shows "waiting for the funds to receiving receiving", go ahead and switch chains in Metamask and reload the page.

## EXPECTED RESULTS
Since the source chain actions are all done, there is no need for any further chain switching unless there is a swap to be carried out as a step.

## CHECKLIST
- [x] I have performed a self-review of my code
- [ ] I have commented the code I wrote to make sure the next developers can understand it
- [ ] I have added tests that cover the new functionality
- [x] I have made sure that existing tests are still passing


[LF-1131]: https://lifi.atlassian.net/browse/LF-1131?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ