### PR TITLE
fix: add insufficient funds error

### DIFF
--- a/src/utils/errors.ts
+++ b/src/utils/errors.ts
@@ -25,11 +25,13 @@ export enum LifiErrorCode {
   TransactionRejected = 1012,
   BalanceError = 1013,
   AllowanceRequired = 1014,
+  InsufficientFunds = 1015,
 }
 
 export enum EthersErrorType {
-  CallExecption = 'CALL_EXCEPTION',
   ActionRejected = 'ACTION_REJECTED',
+  CallExecption = 'CALL_EXCEPTION',
+  InsufficientFunds = 'INSUFFICIENT_FUNDS',
 }
 
 export enum EthersErrorMessage {

--- a/src/utils/parseError.ts
+++ b/src/utils/parseError.ts
@@ -4,11 +4,12 @@ import {
   getMessageFromCode,
 } from 'eth-rpc-errors'
 
+import { fetchTxErrorDetails } from '../helpers'
 import ChainsService from '../services/ChainsService'
 import {
   ErrorMessage,
-  EthersErrorType,
   EthersErrorMessage,
+  EthersErrorType,
   LifiError,
   LifiErrorCode,
   MetaMaskProviderErrorCode,
@@ -22,7 +23,6 @@ import {
   ValidationError,
 } from './errors'
 import { formatTokenAmountOnly } from './utils'
-import { fetchTxErrorDetails } from '../helpers'
 
 /**
  * Available MetaMask error codes:
@@ -203,7 +203,13 @@ export const parseError = async (
           e.stack
         )
       }
-
+    case EthersErrorType.InsufficientFunds:
+      return new TransactionError(
+        LifiErrorCode.InsufficientFunds,
+        e.message,
+        await getTransactionNotSentMessage(step, process),
+        e.stack
+      )
     case EthersErrorType.ActionRejected:
     case MetaMaskProviderErrorCode.userRejectedRequest:
       return new TransactionError(


### PR DESCRIPTION
Sometimes `ethers` can throw INSUFFICIENT_FUNDS error if there is not enough gas to cover the transaction cost. 

Usually, it shouldn't happen because of LI.Fuel and other prevention tools in the widget, but if estimations are wrong, we can see it. 

<img width="421" alt="image" src="https://github.com/lifinance/sdk/assets/18644653/292b2f89-2dea-4985-be1b-e9c1dded5aa6">
