### PR TITLE
fix: added gasLimit as BigNumber

### DIFF
--- a/src/execution/RouteExecutionManager.unit.spec.ts
+++ b/src/execution/RouteExecutionManager.unit.spec.ts
@@ -1,4 +1,4 @@
-import { Signer } from 'ethers'
+import { BigNumber, Signer, ethers } from 'ethers'
 import { setupServer } from 'msw/node'
 import {
   afterAll,
@@ -69,7 +69,7 @@ describe('Should pick up gas from signer estimation', () => {
     await routeExecutionManager.executeRoute(signer, route)
 
     expect(signer.sendTransaction).toHaveBeenCalledWith({
-      gasLimit: '125000',
+      gasLimit: BigNumber.from('125000'),
       gasPrice: 100000,
       // TODO: Check the cause for gasLimit being outside transactionRequest. Currently working as expected in widget
       transactionRequest: {

--- a/src/execution/StepExecutionManager.ts
+++ b/src/execution/StepExecutionManager.ts
@@ -16,6 +16,7 @@ import { isZeroAddress, personalizeStep } from '../utils/utils'
 import { stepComparison } from './stepComparison'
 import { switchChain } from './switchChain'
 import { getSubstatusMessage, waitForReceivingTransaction } from './utils'
+import { BigNumber, ethers } from 'ethers'
 
 export class StepExecutionManager {
   allowUserInteraction = true
@@ -160,9 +161,9 @@ export class StepExecutionManager {
               )
 
               if (estimatedGasLimit) {
-                transactionRequest.gasLimit = `${
-                  (BigInt(estimatedGasLimit.toString()) * 125n) / 100n
-                }`
+                transactionRequest.gasLimit = BigNumber.from(
+                  `${(BigInt(estimatedGasLimit.toString()) * 125n) / 100n}`
+                )
               }
 
               // Fetch latest gasPrice from provider and use it


### PR DESCRIPTION
Fixed "invalid hexlify value" on bridge caused by raw gasLimit