### PR TITLE
fix: parsing params in available connections api request

### DIFF
--- a/src/services/ApiService.ts
+++ b/src/services/ApiService.ts
@@ -434,8 +434,7 @@ const getAvailableConnections = async (
 
   const url = new URL(`${config.apiUrl}/connections`)
 
-  const { fromChain, fromToken, toChain, toToken, allowBridges } =
-    connectionRequest
+  const { fromChain, fromToken, toChain, toToken } = connectionRequest
 
   if (fromChain) {
     url.searchParams.append('fromChain', fromChain as unknown as string)
@@ -450,11 +449,26 @@ const getAvailableConnections = async (
     url.searchParams.append('fromToken', toToken)
   }
 
-  if (allowBridges?.length) {
-    allowBridges.forEach((bridge) => {
-      url.searchParams.append('allowBridges', bridge)
-    })
-  }
+  const connectionRequestArrayParams: Array<keyof ConnectionsRequest> = [
+    'allowBridges',
+    'denyBridges',
+    'preferBridges',
+    'allowExchanges',
+    'denyExchanges',
+    'preferExchanges',
+  ]
+
+  connectionRequestArrayParams.forEach((parameter) => {
+    const connectionRequestArrayParam: string[] = connectionRequest[
+      parameter
+    ] as string[]
+
+    if (connectionRequestArrayParam?.length) {
+      connectionRequestArrayParam?.forEach((value) => {
+        url.searchParams.append(parameter, value)
+      })
+    }
+  })
 
   try {
     const response = await request<ConnectionsResponse>(url)

--- a/src/services/ApiService.unit.spec.ts
+++ b/src/services/ApiService.unit.spec.ts
@@ -704,16 +704,16 @@ describe('ApiService', () => {
         fromToken: findDefaultToken(CoinKey.USDC, ChainId.BSC).address,
         toToken: findDefaultToken(CoinKey.USDC, ChainId.OPT).address,
         allowBridges: ['connext', 'uniswap', 'polygon'],
-        allowExchanges: ['a', 'b', 'c'],
-        denyBridges: ['testValue1', 'testValue2'],
-        preferBridges: ['testValue1', 'testValue2'],
-        denyExchanges: ['testValue1', 'testValue2'],
-        preferExchanges: ['testValue1', 'testValue2'],
+        allowExchanges: ['1inch', 'ParaSwap', 'SushiSwap'],
+        denyBridges: ['Hop', 'Multichain'],
+        preferBridges: ['Hyphen', 'Across'],
+        denyExchanges: ['UbeSwap', 'BeamSwap'],
+        preferExchanges: ['Evmoswap', 'Diffusion'],
       }
 
       const generatedURL =
         // eslint-disable-next-line max-len
-        'https://li.quest/v1/connections?fromChain=56&fromToken=0x8ac76a51cc950d9822d68b83fe1ad97b32cd580d&fromToken=10&fromToken=0x7f5c764cbc14f9669b88837ca1490cca17c31607&allowBridges=connext&allowBridges=uniswap&allowBridges=polygon&denyBridges=testValue1&denyBridges=testValue2&preferBridges=testValue1&preferBridges=testValue2&allowExchanges=a&allowExchanges=b&allowExchanges=c&denyExchanges=testValue1&denyExchanges=testValue2&preferExchanges=testValue1&preferExchanges=testValue2'
+        'https://li.quest/v1/connections?fromChain=56&fromToken=0x8ac76a51cc950d9822d68b83fe1ad97b32cd580d&fromToken=10&fromToken=0x7f5c764cbc14f9669b88837ca1490cca17c31607&allowBridges=connext&allowBridges=uniswap&allowBridges=polygon&denyBridges=Hop&denyBridges=Multichain&preferBridges=Hyphen&preferBridges=Across&allowExchanges=1inch&allowExchanges=ParaSwap&allowExchanges=SushiSwap&denyExchanges=UbeSwap&denyExchanges=BeamSwap&preferExchanges=Evmoswap&preferExchanges=Diffusion'
 
       await expect(
         ApiService.getAvailableConnections(connectionRequest)

--- a/src/services/ApiService.unit.spec.ts
+++ b/src/services/ApiService.unit.spec.ts
@@ -704,11 +704,16 @@ describe('ApiService', () => {
         fromToken: findDefaultToken(CoinKey.USDC, ChainId.BSC).address,
         toToken: findDefaultToken(CoinKey.USDC, ChainId.OPT).address,
         allowBridges: ['connext', 'uniswap', 'polygon'],
+        allowExchanges: ['a', 'b', 'c'],
+        denyBridges: ['testValue1', 'testValue2'],
+        preferBridges: ['testValue1', 'testValue2'],
+        denyExchanges: ['testValue1', 'testValue2'],
+        preferExchanges: ['testValue1', 'testValue2'],
       }
 
       const generatedURL =
         // eslint-disable-next-line max-len
-        'https://li.quest/v1/connections?fromChain=56&fromToken=0x8ac76a51cc950d9822d68b83fe1ad97b32cd580d&fromToken=10&fromToken=0x7f5c764cbc14f9669b88837ca1490cca17c31607&allowBridges=connext&allowBridges=uniswap&allowBridges=polygon'
+        'https://li.quest/v1/connections?fromChain=56&fromToken=0x8ac76a51cc950d9822d68b83fe1ad97b32cd580d&fromToken=10&fromToken=0x7f5c764cbc14f9669b88837ca1490cca17c31607&allowBridges=connext&allowBridges=uniswap&allowBridges=polygon&denyBridges=testValue1&denyBridges=testValue2&preferBridges=testValue1&preferBridges=testValue2&allowExchanges=a&allowExchanges=b&allowExchanges=c&denyExchanges=testValue1&denyExchanges=testValue2&preferExchanges=testValue1&preferExchanges=testValue2'
 
       await expect(
         ApiService.getAvailableConnections(connectionRequest)


### PR DESCRIPTION
# FIX

Parsing all params to get the available connections [LF-3826]

## TL;DR

Fix the issue where only selected params with array value were being parsed, leaving out other array-based params. Now all array params and all values are parsed and passed in the API request.

## DESCRIPTION

Previously, there was an issue where only selected parameters with array values were being parsed, resulting in the exclusion of other array-based parameters. This fix addresses that issue by ensuring that all array parameters and their respective values are parsed and correctly passed in the API request.

## TESTING

No testing is required as this fix is already integrated and tested.

## CHECKLIST

- [x] I have performed a self-review of my code.
- [ ] I have commented the code I wrote to ensure clarity.
- [x] I have made sure that existing tests related to this fix are passing.
- [x] I have verified that the fix resolves the issue described in the ticket.


[LF-3826]: https://lifi.atlassian.net/browse/LF-3826?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ