### PR TITLE
feat: allow to pass api key to all requests

### DIFF
--- a/src/request.ts
+++ b/src/request.ts
@@ -18,12 +18,19 @@ export const request = async <T = Response>(
     retries: requestSettings.retries,
   }
 ): Promise<T> => {
-  const { userId, integrator, widgetVersion } =
+  const { userId, integrator, widgetVersion, apiKey } =
     ConfigService.getInstance().getConfig()
 
   options.retries = options.retries ?? requestSettings.retries
   try {
     if (!options.skipTrackingHeaders) {
+      if (apiKey) {
+        options.headers = {
+          ...options?.headers,
+          'X-LIFI-api-key': apiKey,
+        }
+      }
+
       if (userId) {
         options.headers = {
           ...options?.headers,

--- a/src/request.ts
+++ b/src/request.ts
@@ -27,7 +27,7 @@ export const request = async <T = Response>(
       if (apiKey) {
         options.headers = {
           ...options?.headers,
-          'X-LIFI-api-key': apiKey,
+          'X-LIFI-API-Key': apiKey,
         }
       }
 

--- a/src/request.ts
+++ b/src/request.ts
@@ -27,35 +27,35 @@ export const request = async <T = Response>(
       if (apiKey) {
         options.headers = {
           ...options?.headers,
-          'X-LIFI-API-Key': apiKey,
+          'x-lifi-api-Key': apiKey,
         }
       }
 
       if (userId) {
         options.headers = {
           ...options?.headers,
-          'X-LIFI-UserId': userId,
+          'x-lifi-userid': userId,
         }
       }
 
       if (widgetVersion) {
         options.headers = {
           ...options?.headers,
-          'X-LIFI-Widget': widgetVersion,
+          'x-lifi-widget': widgetVersion,
         }
       }
 
       if (version) {
         options.headers = {
           ...options?.headers,
-          'X-LIFI-SDK': version,
+          'x-lifi-sdk': version,
         }
       }
 
       // integrator is mandatory during SDK initialization
       options.headers = {
         ...options?.headers,
-        'X-LIFI-Integrator': integrator,
+        'x-lifi-integrator': integrator,
       }
     }
 

--- a/src/request.ts
+++ b/src/request.ts
@@ -27,7 +27,7 @@ export const request = async <T = Response>(
       if (apiKey) {
         options.headers = {
           ...options?.headers,
-          'x-lifi-api-Key': apiKey,
+          'x-lifi-api-key': apiKey,
         }
       }
 

--- a/src/services/ConfigService.ts
+++ b/src/services/ConfigService.ts
@@ -107,6 +107,7 @@ export default class ConfigService {
       configUpdate.defaultRouteOptions
     )
 
+    this.config.apiKey = configUpdate.apiKey || this.config.apiKey
     this.config.userId = configUpdate.userId || this.config.userId
     this.config.integrator = configUpdate.integrator || this.config.integrator
     this.config.defaultRouteOptions.integrator =

--- a/src/types/internal.types.ts
+++ b/src/types/internal.types.ts
@@ -34,6 +34,7 @@ export type TransactionRequestUpdateHook = (
 
 export type Config = {
   apiUrl: string
+  apiKey?: string
   rpcs: Record<ChainId, string[]>
   multicallAddresses: Record<ChainId, string | undefined>
   defaultExecutionSettings: InternalExecutionSettings
@@ -75,6 +76,7 @@ export interface MultisigConfig {
 
 export type ConfigUpdate = {
   apiUrl?: string
+  apiKey?: string
   rpcs?: Record<number, string[]>
   multicallAddresses?: Record<number, string | undefined>
   defaultExecutionSettings?: ExecutionSettings


### PR DESCRIPTION
We want to introduce authentication on the Backend API. We need to be able to set this key in the SDK so it's passed with all requests.