### PR TITLE
feat: add multi-contract calls API endpoint

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
   "dependencies": {
     "@ethersproject/abi": "^5.7.0",
     "@ethersproject/contracts": "^5.7.0",
-    "@lifi/types": "^8.4.0",
+    "@lifi/types": "^8.7.0",
     "bignumber.js": "^9.1.1",
     "eth-rpc-errors": "^4.0.3",
     "ethers": "^5.7.2"

--- a/src/LiFi.ts
+++ b/src/LiFi.ts
@@ -6,6 +6,7 @@ import {
   ConnectionsRequest,
   ConnectionsResponse,
   ContractCallQuoteRequest,
+  ContractCallsQuoteRequest,
   ExtendedChain,
   GasRecommendationRequest,
   GasRecommendationResponse,
@@ -143,12 +144,25 @@ export class LiFi extends RouteExecutionManager {
    * Get a quote for a destination contract call
    * @param {ContractCallQuoteRequest} request - The configuration of the requested destination call
    * @throws {LifiError} - Throws a LifiError if request fails
+   * @deprecated This method is deprecated, please use `getContractCallsQuote` instead
    */
   getContractCallQuote = async (
     request: ContractCallQuoteRequest,
     options?: RequestOptions
   ): Promise<LifiStep> => {
     return ApiService.getContractCallQuote(request, options)
+  }
+
+  /**
+   * Get a quotes for multiple destination contract call
+   * @param {ContractCallsQuoteRequest} request - The configuration of the requested destination call
+   * @throws {LifiError} - Throws a LifiError if request fails
+   */
+  getContractCallsQuote = async (
+    request: ContractCallsQuoteRequest,
+    options?: RequestOptions
+  ): Promise<LifiStep> => {
+    return ApiService.getContractCallsQuote(request, options)
   }
 
   /**

--- a/src/services/ApiService.ts
+++ b/src/services/ApiService.ts
@@ -2,6 +2,7 @@ import {
   ConnectionsRequest,
   ConnectionsResponse,
   ContractCallQuoteRequest,
+  ContractCallsQuoteRequest,
   GasRecommendationRequest,
   GasRecommendationResponse,
   GetStatusRequest,
@@ -206,6 +207,68 @@ const getContractCallQuote = async (
   try {
     const response = await request<LifiStep>(
       `${config.apiUrl}/quote/contractCall`,
+      {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify(requestConfig),
+        signal: options?.signal,
+      }
+    )
+
+    return response
+  } catch (e) {
+    throw await parseBackendError(e)
+  }
+}
+
+const getContractCallsQuote = async (
+  requestConfig: ContractCallsQuoteRequest,
+  options?: RequestOptions
+): Promise<LifiStep> => {
+  const config = ConfigService.getInstance().getConfig()
+
+  // validation
+  const requiredParameters: Array<keyof ContractCallsQuoteRequest> = [
+    'fromChain',
+    'fromToken',
+    'fromAddress',
+    'toChain',
+    'toToken',
+    'toAmount',
+    'contractCalls',
+  ]
+
+  if (requestConfig.contractCalls.length === 0) {
+    throw new ValidationError(`Parameter "contractCalls" is empty.`)
+  }
+
+  requiredParameters.forEach((requiredParameter) => {
+    if (!requestConfig[requiredParameter]) {
+      throw new ValidationError(
+        `Required parameter "${requiredParameter}" is missing.`
+      )
+    }
+  })
+
+  // apply defaults
+  // option.order is not used in this endpoint
+  requestConfig.slippage ||= config.defaultRouteOptions.slippage
+  requestConfig.integrator ||= config.defaultRouteOptions.integrator
+  requestConfig.referrer ||= config.defaultRouteOptions.referrer
+
+  requestConfig.allowBridges ||= config.defaultRouteOptions.bridges?.allow
+  requestConfig.denyBridges ||= config.defaultRouteOptions.bridges?.deny
+  requestConfig.preferBridges ||= config.defaultRouteOptions.bridges?.prefer
+  requestConfig.allowExchanges ||= config.defaultRouteOptions.exchanges?.allow
+  requestConfig.denyExchanges ||= config.defaultRouteOptions.exchanges?.deny
+  requestConfig.preferExchanges ||= config.defaultRouteOptions.exchanges?.prefer
+
+  // send request
+  try {
+    const response = await request<LifiStep>(
+      `${config.apiUrl}/quote/contractCalls`,
       {
         method: 'POST',
         headers: {
@@ -460,6 +523,7 @@ const getAvailableConnections = async (
 export default {
   getChains,
   getContractCallQuote,
+  getContractCallsQuote,
   getGasRecommendation,
   getPossibilities,
   getQuote,

--- a/src/services/ApiService.ts
+++ b/src/services/ApiService.ts
@@ -206,7 +206,7 @@ const getContractCallQuote = async (
   // send request
   try {
     const response = await request<LifiStep>(
-      `${config.apiUrl}/quote/contractCalls`,
+      `${config.apiUrl}/quote/contractCall`,
       {
         method: 'POST',
         headers: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1003,7 +1003,7 @@ __metadata:
     "@commitlint/config-conventional": ^17.6.7
     "@ethersproject/abi": ^5.7.0
     "@ethersproject/contracts": ^5.7.0
-    "@lifi/types": ^8.4.0
+    "@lifi/types": ^8.7.0
     "@mswjs/interceptors": ^0.22.16
     "@typescript-eslint/eslint-plugin": ^6.1.0
     "@typescript-eslint/parser": ^6.1.0
@@ -1027,12 +1027,12 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@lifi/types@npm:^8.4.0":
-  version: 8.4.0
-  resolution: "@lifi/types@npm:8.4.0"
+"@lifi/types@npm:^8.7.0":
+  version: 8.7.0
+  resolution: "@lifi/types@npm:8.7.0"
   dependencies:
     ethers: ^5.7.2
-  checksum: 54cc658b2d04b10c3faff72ac1bcbc5c69e5699be320dd913a15f4c2b2fdb6b4b888b488ffc40e90b4131ae6e5611677b863ac867227a7c1e19d1d9d8c434021
+  checksum: 230b468de2411a8683c5caf2ed9295920d236463e81acc9c60aeb25a99835a971554a1b6198a5b7e44099e0a72b77b6417a035a2776be0903a669afebb6e2d08
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
# ⚠️ Deprecation

The method: `getContractCallQuote` is being deprecated and `getContractCallsQuote` must be used instead.

## Added Multi-contract call api endpoint

new method `getContractCallsQuote` is added to enable user to get quotes from multiple contract calls

