### PR TITLE
fix: wallet analytics API request changes

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
   "dependencies": {
     "@ethersproject/abi": "^5.7.0",
     "@ethersproject/contracts": "^5.7.0",
-    "@lifi/types": "^9.0.2",
+    "@lifi/types": "^9.0.3",
     "bignumber.js": "^9.1.2",
     "eth-rpc-errors": "^4.0.3",
     "ethers": "^5.7.2"

--- a/src/LiFi.ts
+++ b/src/LiFi.ts
@@ -27,6 +27,7 @@ import {
   ToolsRequest,
   ToolsResponse,
   WalletAnalytics,
+  WalletAnalyticsRequest,
 } from '@lifi/types'
 import { Signer } from 'ethers'
 import {
@@ -44,12 +45,7 @@ import { checkPackageUpdates } from './helpers'
 import ApiService from './services/ApiService'
 import ChainsService from './services/ChainsService'
 import { isToken } from './typeguards'
-import {
-  Config,
-  ConfigUpdate,
-  RevokeTokenData,
-  WalletAnalyticsRequest,
-} from './types'
+import { Config, ConfigUpdate, RevokeTokenData } from './types'
 import { ValidationError } from './utils/errors'
 import { name, version } from './version'
 

--- a/src/LiFi.ts
+++ b/src/LiFi.ts
@@ -391,10 +391,10 @@ export class LiFi extends RouteExecutionManager {
   getTransactionHistory = async (
     walletAnalyticsRequest: WalletAnalyticsRequest
   ): Promise<WalletAnalytics> => {
-    const connections = await ApiService.getTransactionHistory(
+    const transactions = await ApiService.getTransactionHistory(
       walletAnalyticsRequest
     )
 
-    return connections
+    return transactions
   }
 }

--- a/src/LiFi.ts
+++ b/src/LiFi.ts
@@ -44,7 +44,12 @@ import { checkPackageUpdates } from './helpers'
 import ApiService from './services/ApiService'
 import ChainsService from './services/ChainsService'
 import { isToken } from './typeguards'
-import { Config, ConfigUpdate, RevokeTokenData } from './types'
+import {
+  Config,
+  ConfigUpdate,
+  RevokeTokenData,
+  WalletAnalyticsRequest,
+} from './types'
 import { ValidationError } from './utils/errors'
 import { name, version } from './version'
 
@@ -384,11 +389,15 @@ export class LiFi extends RouteExecutionManager {
 
   /**
    * Get all the transaction history for swap/bridging done via LiFi
-   * @param address string
+   * @param walletAnalyticsRequest WalletAnalyticsRequest
    * @returns WalletAnalytics
    */
-  getTransactionHistory = async (address: string): Promise<WalletAnalytics> => {
-    const connections = await ApiService.getTransactionHistory(address)
+  getTransactionHistory = async (
+    walletAnalyticsRequest: WalletAnalyticsRequest
+  ): Promise<WalletAnalytics> => {
+    const connections = await ApiService.getTransactionHistory(
+      walletAnalyticsRequest
+    )
 
     return connections
   }

--- a/src/services/ApiService.ts
+++ b/src/services/ApiService.ts
@@ -28,6 +28,7 @@ import {
   Token,
   ToolsRequest,
   ToolsResponse,
+  WalletAnalyticsRequest,
 } from '../types'
 import { ValidationError } from '../utils/errors'
 import { parseBackendError } from '../utils/parseError'
@@ -522,13 +523,37 @@ const getAvailableConnections = async (
 }
 
 const getTransactionHistory = async (
-  address: string
+  walletAnalyticsRequest: WalletAnalyticsRequest
 ): Promise<WalletAnalytics> => {
   const config = ConfigService.getInstance().getConfig()
 
-  const response = await request<WalletAnalytics>(
-    `${config.apiUrl}/analytics/wallets/${address}`
+  if (!walletAnalyticsRequest.fromTimestamp) {
+    throw new ValidationError('Required parameter "fromTimestamp" is missing.')
+  }
+
+  if (!walletAnalyticsRequest.toTimestamp) {
+    throw new ValidationError('Required parameter "toTimestamp" is missing.')
+  }
+
+  const url = new URL(
+    `${config.apiUrl}/analytics/wallets/${walletAnalyticsRequest.wallet_address}`
   )
+
+  url.searchParams.append(
+    'fromTimestamp',
+    walletAnalyticsRequest.fromTimestamp.toString()
+  )
+
+  url.searchParams.append(
+    'toTimestamp',
+    walletAnalyticsRequest.toTimestamp.toString()
+  )
+
+  if (walletAnalyticsRequest.integrator) {
+    url.searchParams.append('integrator', walletAnalyticsRequest.integrator)
+  }
+
+  const response = await request<WalletAnalytics>(url)
 
   return response
 }

--- a/src/services/ApiService.ts
+++ b/src/services/ApiService.ts
@@ -12,6 +12,7 @@ import {
   TokensRequest,
   TokensResponse,
   WalletAnalytics,
+  WalletAnalyticsRequest,
 } from '@lifi/types'
 import { request } from '../request'
 import { isRoutesRequest, isStep } from '../typeguards'
@@ -28,7 +29,6 @@ import {
   Token,
   ToolsRequest,
   ToolsResponse,
-  WalletAnalyticsRequest,
 } from '../types'
 import { ValidationError } from '../utils/errors'
 import { parseBackendError } from '../utils/parseError'
@@ -536,7 +536,7 @@ const getTransactionHistory = async (
   }
 
   const url = new URL(
-    `${config.apiUrl}/analytics/wallets/${walletAnalyticsRequest.wallet_address}`
+    `${config.apiUrl}/analytics/wallets/${walletAnalyticsRequest.walletAddress}`
   )
 
   url.searchParams.append(
@@ -549,8 +549,8 @@ const getTransactionHistory = async (
     walletAnalyticsRequest.toTimestamp.toString()
   )
 
-  if (walletAnalyticsRequest.integrator) {
-    url.searchParams.append('integrator', walletAnalyticsRequest.integrator)
+  if (config.integrator) {
+    url.searchParams.append('integrator', config.integrator)
   }
 
   const response = await request<WalletAnalytics>(url)

--- a/src/services/ApiService.ts
+++ b/src/services/ApiService.ts
@@ -549,10 +549,6 @@ const getTransactionHistory = async (
     walletAnalyticsRequest.toTimestamp.toString()
   )
 
-  if (config.integrator) {
-    url.searchParams.append('integrator', config.integrator)
-  }
-
   const response = await request<WalletAnalytics>(url)
 
   return response

--- a/src/services/ApiService.unit.spec.ts
+++ b/src/services/ApiService.unit.spec.ts
@@ -26,6 +26,7 @@ import { ServerError, SlippageError, ValidationError } from '../utils/errors'
 import ApiService from './ApiService'
 import { handlers } from './ApiService.unit.handlers'
 import ConfigService from './ConfigService'
+import { WalletAnalyticsRequest } from '..'
 
 const mockedFetch = vi.spyOn(globalThis, 'fetch')
 
@@ -720,6 +721,34 @@ describe('ApiService', () => {
       ).resolves.toEqual({
         connections: [],
       })
+
+      expect((mockedFetch.mock.calls[0][0] as URL).href).toEqual(generatedURL)
+      expect(mockedFetch).toHaveBeenCalledOnce()
+    })
+  })
+  describe('getTransactionHistory', () => {
+    it('returns empty array in response', async () => {
+      server.use(
+        rest.get(
+          `${config.apiUrl}/analytics/wallets/0x5520abcd`,
+          async (_, response, context) =>
+            response(context.status(200), context.json({ connections: [] }))
+        )
+      )
+
+      const walletAnalyticsRequest: WalletAnalyticsRequest = {
+        fromTimestamp: 1696326609361,
+        toTimestamp: 1696326609362,
+        wallet_address: '0x5520abcd',
+        integrator: 'lifi-test-suite',
+      }
+
+      const generatedURL =
+        'https://li.quest/v1/analytics/wallets/0x5520abcd?fromTimestamp=1696326609361&toTimestamp=1696326609362&integrator=lifi-test-suite'
+
+      await expect(
+        ApiService.getTransactionHistory(walletAnalyticsRequest)
+      ).resolves.toEqual({})
 
       expect((mockedFetch.mock.calls[0][0] as URL).href).toEqual(generatedURL)
       expect(mockedFetch).toHaveBeenCalledOnce()

--- a/src/services/ApiService.unit.spec.ts
+++ b/src/services/ApiService.unit.spec.ts
@@ -739,8 +739,7 @@ describe('ApiService', () => {
       const walletAnalyticsRequest: WalletAnalyticsRequest = {
         fromTimestamp: 1696326609361,
         toTimestamp: 1696326609362,
-        wallet_address: '0x5520abcd',
-        integrator: 'lifi-test-suite',
+        walletAddress: '0x5520abcd',
       }
 
       const generatedURL =

--- a/src/services/ApiService.unit.spec.ts
+++ b/src/services/ApiService.unit.spec.ts
@@ -8,6 +8,7 @@ import {
   LifiStep,
   RoutesRequest,
   StepTool,
+  WalletAnalyticsRequest,
 } from '@lifi/types'
 import { rest } from 'msw'
 import { setupServer } from 'msw/node'
@@ -26,7 +27,6 @@ import { ServerError, SlippageError, ValidationError } from '../utils/errors'
 import ApiService from './ApiService'
 import { handlers } from './ApiService.unit.handlers'
 import ConfigService from './ConfigService'
-import { WalletAnalyticsRequest } from '..'
 
 const mockedFetch = vi.spyOn(globalThis, 'fetch')
 

--- a/src/services/ApiService.unit.spec.ts
+++ b/src/services/ApiService.unit.spec.ts
@@ -743,7 +743,7 @@ describe('ApiService', () => {
       }
 
       const generatedURL =
-        'https://li.quest/v1/analytics/wallets/0x5520abcd?fromTimestamp=1696326609361&toTimestamp=1696326609362&integrator=lifi-test-suite'
+        'https://li.quest/v1/analytics/wallets/0x5520abcd?fromTimestamp=1696326609361&toTimestamp=1696326609362&integrator=lifi-sdk'
 
       await expect(
         ApiService.getTransactionHistory(walletAnalyticsRequest)

--- a/src/services/ApiService.unit.spec.ts
+++ b/src/services/ApiService.unit.spec.ts
@@ -732,7 +732,7 @@ describe('ApiService', () => {
         rest.get(
           `${config.apiUrl}/analytics/wallets/0x5520abcd`,
           async (_, response, context) =>
-            response(context.status(200), context.json({ connections: [] }))
+            response(context.status(200), context.json({}))
         )
       )
 

--- a/src/services/ApiService.unit.spec.ts
+++ b/src/services/ApiService.unit.spec.ts
@@ -743,7 +743,7 @@ describe('ApiService', () => {
       }
 
       const generatedURL =
-        'https://li.quest/v1/analytics/wallets/0x5520abcd?fromTimestamp=1696326609361&toTimestamp=1696326609362&integrator=lifi-sdk'
+        'https://li.quest/v1/analytics/wallets/0x5520abcd?fromTimestamp=1696326609361&toTimestamp=1696326609362'
 
       await expect(
         ApiService.getTransactionHistory(walletAnalyticsRequest)

--- a/src/types/internal.types.ts
+++ b/src/types/internal.types.ts
@@ -191,3 +191,10 @@ export interface Signature {
   r: string
   s: string
 }
+
+export interface WalletAnalyticsRequest {
+  wallet_address: string
+  fromTimestamp: number
+  toTimestamp: number
+  integrator?: string
+}

--- a/src/types/internal.types.ts
+++ b/src/types/internal.types.ts
@@ -191,10 +191,3 @@ export interface Signature {
   r: string
   s: string
 }
-
-export interface WalletAnalyticsRequest {
-  wallet_address: string
-  fromTimestamp: number
-  toTimestamp: number
-  integrator?: string
-}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1003,7 +1003,7 @@ __metadata:
     "@commitlint/config-conventional": ^17.7.0
     "@ethersproject/abi": ^5.7.0
     "@ethersproject/contracts": ^5.7.0
-    "@lifi/types": ^9.0.2
+    "@lifi/types": ^9.0.3
     "@mswjs/interceptors": ^0.22.16
     "@typescript-eslint/eslint-plugin": ^6.7.2
     "@typescript-eslint/parser": ^6.7.2
@@ -1027,12 +1027,12 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@lifi/types@npm:^9.0.2":
-  version: 9.0.2
-  resolution: "@lifi/types@npm:9.0.2"
+"@lifi/types@npm:^9.0.3":
+  version: 9.0.3
+  resolution: "@lifi/types@npm:9.0.3"
   dependencies:
     ethers: ^5.7.2
-  checksum: 2b8bab6ab00270d3608f8e303ad2a34233fb60c6bc9eda3e42403ce5a14b7d6648042cf400e630f62791fc55477831236e6e2f8137077b9878eee2648acef38b
+  checksum: b69c9c005c6c136ded8ea13d38c991fceb67a5244b01671b452864cc97f221bbfaed1ee9ae8a0fc6a05f8f0d5ab0ffea3aaae9ccfff6bdd2d10fca874620b117
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
There are changes from backend in the request config for the analytics API, 
https://github.com/lifinance/lifi-backend/pull/2770

[API Reference](https://apidocs.li.fi/reference/get_analytics-wallets-wallet-address-1)