### PR TITLE
fix: default imports for parcel bundler

### DIFF
--- a/src/LiFi.ts
+++ b/src/LiFi.ts
@@ -38,7 +38,7 @@ import {
   getTokenApproval,
   revokeTokenApproval,
 } from './allowance'
-import * as balance from './balance'
+import balance from './balance'
 import { getRpcProvider } from './connectors'
 import { RouteExecutionManager } from './execution/RouteExecutionManager'
 import { checkPackageUpdates } from './helpers'
@@ -54,7 +54,6 @@ export class LiFi extends RouteExecutionManager {
 
   constructor(configUpdate: ConfigUpdate) {
     super(configUpdate)
-
     this.chainsService = ChainsService.getInstance()
 
     this.chainsService.getChains().then((chains) => {

--- a/src/LiFi.unit.spec.ts
+++ b/src/LiFi.unit.spec.ts
@@ -2,14 +2,19 @@ import { ChainId, CoinKey, Token, findDefaultToken } from '@lifi/types'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { buildStepObject } from '../test/fixtures'
 import { LiFi } from './LiFi'
-import * as balance from './balance'
+import balance from './balance'
 import { convertQuoteToRoute } from './helpers'
 
-vi.mock('./balance', () => ({
-  getTokenBalancesForChains: vi.fn(() => Promise.resolve([])),
-  getTokenBalance: vi.fn(() => Promise.resolve([])),
-  getTokenBalances: vi.fn(() => Promise.resolve([])),
-}))
+vi.mock('./balance', async () => {
+  const actual = await vi.importActual<typeof import('./balance')>('./balance')
+  return {
+    ...actual,
+    getTokenBalancesForChains: vi.fn(() => Promise.resolve([])),
+    getTokenBalance: vi.fn(() => Promise.resolve([])),
+    getTokenBalances: vi.fn(() => Promise.resolve([])),
+    checkBalance: vi.fn(() => Promise.resolve([])),
+  }
+})
 
 const mockedGetTokenBalance = vi.spyOn(balance, 'getTokenBalance')
 const mockedGetTokenBalances = vi.spyOn(balance, 'getTokenBalances')


### PR DESCRIPTION
Ticket: https://lifi.atlassian.net/browse/LF-7519

Description
- importing balance logic by calling `import * as balance from './balance` caused issues in parcel production builds

Changes:
- changing import of balance handling logic due to issues with using the SDK in the parcel bundler
- updating tests with same import changes and updating the mocking logic for the balance functions

I created a small js app with parcel and react in order to reproduce this issue locally. The changes in this PR fix the issues. 
I also used the local build  in a vite react js project after making the changes just to be sure.
