### PR TITLE
Fix-import-for-check-balance-for-parcel-bundler

### DIFF
--- a/src/execution/RouteExecutionManager.unit.spec.ts
+++ b/src/execution/RouteExecutionManager.unit.spec.ts
@@ -15,7 +15,7 @@ import { requestSettings } from '../request'
 import { RouteExecutionManager } from './RouteExecutionManager'
 import { lifiHandlers } from './RouteExecutionManager.unit.handlers'
 
-vi.mock('../balance', () => ({
+vi.mock('../balance/checkBalance', () => ({
   checkBalance: vi.fn(() => Promise.resolve([])),
 }))
 

--- a/src/execution/StepExecutionManager.ts
+++ b/src/execution/StepExecutionManager.ts
@@ -6,7 +6,7 @@ import {
 import { Execution, ExtendedTransactionInfo, FullStatusData } from '@lifi/types'
 import { BigNumber } from 'ethers'
 import { checkAllowance } from '../allowance'
-import { checkBalance } from '../balance'
+import { checkBalance } from '../balance/checkBalance'
 import ApiService from '../services/ApiService'
 import ChainsService from '../services/ChainsService'
 import { BaseTransaction, ExecutionParams } from '../types'


### PR DESCRIPTION
Similar to #182 

I brought up the previous issue(#182)  in lifi-discord, the issue was fixed with `getTokenBalance` but a similar issue remained with `execute` function.

Description :

- Importing `checkBalance` from "./balance" causes error while `Swapping` in the `widget` or using execute in `sdk` , when building with parcel, Scope hoisting introduces errors where an export is undefined.

 More info here : https://github.com/parcel-bundler/parcel/issues/6071

<img width="1512" alt="Screenshot 2024-04-18 at 11 14 28 PM" src="https://github.com/lifinance/sdk/assets/51452848/937c9b52-d987-4c0b-9f0f-1cf11a9c7b18">
Changes:

- Changed the import of `checkBalance` function and directly imported it from ./balance/checkBalance , swapping now works perfectly
- Updated the unit test with the new import changes


Tested out the changes by using the library locally and Swapping works fine with these changes 
