### PR TITLE
feat: remove response message prop name from http error message

### DIFF
--- a/src/errors/SDKError.unit.spec.ts
+++ b/src/errors/SDKError.unit.spec.ts
@@ -55,7 +55,7 @@ describe('SDKError', () => {
       }
 
       expect(() => testFunction()).toThrowError(
-        `[HTTPError] [ValidationError] Request failed with status code 400 Bad Request\n        responseMessage: Oops\nLI.FI SDK version: ${version}`
+        `[HTTPError] [ValidationError] Request failed with status code 400 Bad Request. Oops\nLI.FI SDK version: ${version}`
       )
     })
   })

--- a/src/errors/httpError.ts
+++ b/src/errors/httpError.ts
@@ -81,10 +81,10 @@ export class HTTPError extends BaseError {
     try {
       this.responseBody = await this.response.json()
 
-      const spacer = '\n        '
-
       if (this.responseBody) {
-        this.message += `${spacer}responseMessage: ${this.responseBody?.message.toString().replaceAll('\n', spacer)}`
+        this.message += this.message.endsWith('.')
+          ? ` ${this.responseBody?.message.toString()}`
+          : `. ${this.responseBody?.message.toString()}`
       }
     } catch {}
 

--- a/src/errors/httpError.unit.spec.ts
+++ b/src/errors/httpError.unit.spec.ts
@@ -19,8 +19,7 @@ describe('HTTPError', () => {
         code: LiFiErrorCode.ValidationError,
         jsonFunc: () => Promise.resolve(responseBody),
         responseBody,
-        builtMessage: `[ValidationError] Request failed with status code 400 Bad Request
-        responseMessage: Oops`,
+        builtMessage: `[ValidationError] Request failed with status code 400 Bad Request. Oops`,
       },
     ],
     [
@@ -34,8 +33,7 @@ describe('HTTPError', () => {
         code: LiFiErrorCode.NotFound,
         jsonFunc: () => Promise.resolve(responseBody),
         responseBody,
-        builtMessage: `[NotFoundError] Request failed with status code 404 Not Found
-        responseMessage: Oops`,
+        builtMessage: `[NotFoundError] Request failed with status code 404 Not Found. Oops`,
       },
     ],
     [
@@ -50,8 +48,7 @@ describe('HTTPError', () => {
         code: LiFiErrorCode.SlippageError,
         jsonFunc: () => Promise.resolve(responseBody),
         responseBody,
-        builtMessage: `[SlippageError] Request failed with status code 409 Conflict\nThe slippage is larger than the defined threshold. Please request a new route to get a fresh quote.
-        responseMessage: Oops`,
+        builtMessage: `[SlippageError] Request failed with status code 409 Conflict\nThe slippage is larger than the defined threshold. Please request a new route to get a fresh quote. Oops`,
       },
     ],
     [
@@ -66,8 +63,7 @@ describe('HTTPError', () => {
         code: LiFiErrorCode.InternalError,
         jsonFunc: () => Promise.resolve(responseBody),
         responseBody,
-        builtMessage: `[ServerError] Request failed with status code 500 Internal Server Error
-        responseMessage: Oops`,
+        builtMessage: `[ServerError] Request failed with status code 500 Internal Server Error. Oops`,
       },
     ],
     [
@@ -81,8 +77,7 @@ describe('HTTPError', () => {
         code: LiFiErrorCode.InternalError,
         jsonFunc: () => Promise.resolve(responseBody),
         responseBody,
-        builtMessage: `[ServerError] Request failed with an unknown error
-        responseMessage: Oops`,
+        builtMessage: `[ServerError] Request failed with an unknown error. Oops`,
       },
     ],
     [


### PR DESCRIPTION
Jira: [LF-9252](https://lifi.atlassian.net/browse/LF-9252)

removing 'responseMessage' from http errors