### PR TITLE
Execute send transaction from Viem client

### DIFF
--- a/src/core/EVM/EVMStepExecutor.ts
+++ b/src/core/EVM/EVMStepExecutor.ts
@@ -5,6 +5,7 @@ import type {
 } from '@lifi/types'
 import type { Client, Hash, SendTransactionParameters } from 'viem'
 import { getAddresses, sendTransaction } from 'viem/actions'
+import { getAction } from 'viem/utils'
 import { config } from '../../config.js'
 import { LiFiErrorCode } from '../../errors/constants.js'
 import { TransactionError, ValidationError } from '../../errors/errors.js'
@@ -308,7 +309,11 @@ export class EVMStepExecutor extends BaseStepExecutor {
               )
             }
           } else {
-            txHash = await sendTransaction(this.client, {
+            txHash = await getAction(
+              this.client,
+              sendTransaction,
+              'sendTransaction'
+            )({
               to: transactionRequest.to,
               account: this.client.account!,
               data: transactionRequest.data,

--- a/src/core/EVM/EVMStepExecutor.ts
+++ b/src/core/EVM/EVMStepExecutor.ts
@@ -3,7 +3,12 @@ import type {
   FullStatusData,
   Process,
 } from '@lifi/types'
-import type { Client, Hash, SendTransactionParameters } from 'viem'
+import type {
+  Client,
+  GetAddressesReturnType,
+  Hash,
+  SendTransactionParameters,
+} from 'viem'
 import { getAddresses, sendTransaction } from 'viem/actions'
 import { getAction } from 'viem/utils'
 import { config } from '../../config.js'
@@ -64,7 +69,11 @@ export class EVMStepExecutor extends BaseStepExecutor {
     // Prevent execution of the quote by wallet different from the one which requested the quote
     let accountAddress = this.client.account?.address
     if (!accountAddress) {
-      const accountAddresses = await getAddresses(this.client)
+      const accountAddresses = (await getAction(
+        this.client,
+        getAddresses,
+        'getAddresses'
+      )(undefined)) as GetAddressesReturnType
       accountAddress = accountAddresses?.[0]
     }
     if (accountAddress !== step.action.fromAddress) {

--- a/src/core/EVM/setAllowance.ts
+++ b/src/core/EVM/setAllowance.ts
@@ -1,6 +1,7 @@
 import type { Client, Hash, SendTransactionParameters } from 'viem'
 import { encodeFunctionData } from 'viem'
 import { sendTransaction } from 'viem/actions'
+import { getAction } from 'viem/utils'
 import { isNativeTokenAddress } from '../../utils/isZeroAddress.js'
 import type { ExecutionOptions, TransactionParameters } from '../types.js'
 import { approveAbi } from './abi.js'
@@ -48,7 +49,11 @@ export const setAllowance = async (
     }
   }
 
-  return sendTransaction(client, {
+  return getAction(
+    client,
+    sendTransaction,
+    'sendTransaction'
+  )({
     to: transactionRequest.to,
     account: client.account!,
     data: transactionRequest.data,

--- a/src/core/EVM/switchChain.ts
+++ b/src/core/EVM/switchChain.ts
@@ -1,5 +1,6 @@
-import type { Client } from 'viem'
+import type { Client, GetChainIdReturnType } from 'viem'
 import { getChainId } from 'viem/actions'
+import { getAction } from 'viem/utils'
 import { LiFiErrorCode } from '../../errors/constants.js'
 import { ProviderError } from '../../errors/errors.js'
 import type { StatusManager } from '../StatusManager.js'
@@ -30,7 +31,11 @@ export const switchChain = async (
   switchChainHook?: SwitchChainHook
 ): Promise<Client | undefined> => {
   // if we are already on the correct chain we can proceed directly
-  const currentChainId = await getChainId(client)
+  const currentChainId = (await getAction(
+    client,
+    getChainId,
+    'getChainId'
+  )(undefined)) as GetChainIdReturnType
   if (currentChainId === step.action.fromChainId) {
     return client
   }
@@ -53,7 +58,11 @@ export const switchChain = async (
     const updatedClient = await switchChainHook?.(step.action.fromChainId)
     let updatedChainId: number | undefined
     if (updatedClient) {
-      updatedChainId = await getChainId(updatedClient)
+      updatedChainId = (await getAction(
+        updatedClient,
+        getChainId,
+        'getChainId'
+      )(undefined)) as GetChainIdReturnType
     }
     if (updatedChainId !== step.action.fromChainId) {
       throw new ProviderError(


### PR DESCRIPTION
## Summary
To enable execution from more complex wallet clients (e.g. smart wallet account clients), the send transaction Viem function is usually overwritten to handle sending these transactions. Viem currently doesn't support the execution of smart accounts in their default send transaction function.

Viem uses a `getAction` util function to execute a given function on the client or default to Viem's default function, which I believe should be used within the SDK.