### PR TITLE
Avoid message signing with flag

### DIFF
--- a/src/core/EVM/EVMStepExecutor.ts
+++ b/src/core/EVM/EVMStepExecutor.ts
@@ -237,7 +237,7 @@ export class EVMStepExecutor extends BaseStepExecutor {
     // Check if step requires permit signature and will be used with relayer service
     const isRelayerTransaction = isRelayerStep(step)
 
-    // Check if wallet can sign messages, usefully for smart wallet accounts
+    // Check if the wallet supports message signing - useful for smart contract wallets
     const disableMessageSigning = this.executionOptions?.disableMessageSigning
 
     // Check if chain has Permit2 contract deployed. Permit2 should not be available for atomic batch.

--- a/src/core/EVM/EVMStepExecutor.ts
+++ b/src/core/EVM/EVMStepExecutor.ts
@@ -237,12 +237,16 @@ export class EVMStepExecutor extends BaseStepExecutor {
     // Check if step requires permit signature and will be used with relayer service
     const isRelayerTransaction = isRelayerStep(step)
 
+    // Check if wallet can sign messages, usefully for smart wallet accounts
+    const disableMessageSigning = this.executionOptions?.disableMessageSigning
+
     // Check if chain has Permit2 contract deployed. Permit2 should not be available for atomic batch.
     const permit2Supported =
       !!fromChain.permit2 &&
       !!fromChain.permit2Proxy &&
       !batchingSupported &&
-      !isFromNativeToken
+      !isFromNativeToken &&
+      !disableMessageSigning
 
     const checkForAllowance =
       // No existing swap/bridge transaction is pending
@@ -262,6 +266,7 @@ export class EVMStepExecutor extends BaseStepExecutor {
         allowUserInteraction: this.allowUserInteraction,
         batchingSupported,
         permit2Supported,
+        disableMessageSigning,
       })
 
       if (allowanceResult.status === 'BATCH_APPROVAL') {

--- a/src/core/EVM/checkAllowance.ts
+++ b/src/core/EVM/checkAllowance.ts
@@ -23,6 +23,7 @@ export type CheckAllowanceParams = {
   allowUserInteraction?: boolean
   batchingSupported?: boolean
   permit2Supported?: boolean
+  disableMessageSigning?: boolean
 }
 
 export type AllowanceResult =
@@ -47,6 +48,7 @@ export const checkAllowance = async ({
   allowUserInteraction = false,
   batchingSupported = false,
   permit2Supported = false,
+  disableMessageSigning = false,
 }: CheckAllowanceParams): Promise<AllowanceResult> => {
   // Find existing or create new allowance process
   const allowanceProcess: Process = statusManager.findOrCreateProcess({
@@ -116,7 +118,10 @@ export const checkAllowance = async ({
 
     // Check if proxy contract is available and token supports native permits, not available for atomic batch
     const nativePermitSupported =
-      !!nativePermitData && !!chain.permit2Proxy && !batchingSupported
+      !!nativePermitData &&
+      !!chain.permit2Proxy &&
+      !batchingSupported &&
+      !disableMessageSigning
 
     if (nativePermitSupported && nativePermitData) {
       const signature = await getAction(

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -114,6 +114,7 @@ export interface ExecutionOptions {
   updateRouteHook?: UpdateRouteHook
   updateTransactionRequestHook?: TransactionRequestUpdateHook
   executeInBackground?: boolean
+  disableMessageSigning?: boolean
   /**
    * @deprecated
    */


### PR DESCRIPTION
## Summary
Recently, token approvals were done by signing a message for tokens supporting [EIP-2612](https://eips.ethereum.org/EIPS/eip-2612). This is great for avoiding executing a transaction to approve tokens only, but it doesn't work for all wallets. 

Permit doesn't work for smart wallet accounts since EIP-2612 omits ERC-1271, which is often used to "sign" messages by smart wallet accounts. 

To still allow smart wallet accounts to use LiFi's SDK, I propose a configuration flag `disableMessageSigning` that skips the Permit logic and always executes a token approval. 