### PR TITLE
Fix typo in process variable name and simplify needed balance formatting

### DIFF
--- a/src/core/StatusManager.ts
+++ b/src/core/StatusManager.ts
@@ -116,7 +116,7 @@ export class StatusManager {
    * @param step The step that should contain the new process.
    * @param type Type of the process. Used to identify already existing processes.
    * @param chainId Chain Id of the process.
-   * @param status By default created procces is set to the STARTED status. We can override new process with the needed status.
+   * @param status By default created process is set to the STARTED status. We can override new process with the needed status.
    * @returns Returns process.
    */
   findOrCreateProcess = ({

--- a/src/core/checkBalance.ts
+++ b/src/core/checkBalance.ts
@@ -27,9 +27,9 @@ export const checkBalance = async (
         // adjust amount in slippage limits
         step.action.fromAmount = currentBalance.toString()
       } else {
-        const neeeded = formatUnits(neededBalance, token.decimals)
+        const needed = formatUnits(neededBalance, token.decimals)
         const current = formatUnits(currentBalance, token.decimals)
-        let errorMessage = `Your ${token.symbol} balance is too low, you try to transfer ${neeeded} ${token.symbol}, but your wallet only holds ${current} ${token.symbol}. No funds have been sent.`
+        let errorMessage = `Your ${token.symbol} balance is too low, you try to transfer ${needed} ${token.symbol}, but your wallet only holds ${current} ${token.symbol}. No funds have been sent.`
 
         if (currentBalance !== 0n) {
           errorMessage += `If the problem consists, please delete this transfer and start a new one with a maximum of ${current} ${token.symbol}.`


### PR DESCRIPTION
This PR includes the following changes:

1. In StatusManager.ts:
- Fixed typo in @param documentation by correcting "procees" to "process"

2. In checkBalance.ts:
- Simplified variable naming by changing "neeeded" to "needed"
- Fixed string template formatting for error message while maintaining the same functionality

These changes improve code consistency and fix minor typos without changing any core functionality.