### PR TITLE
fix(utxo): add check for when inputs are already final

### DIFF
--- a/src/core/UTXO/UTXOStepExecutor.ts
+++ b/src/core/UTXO/UTXOStepExecutor.ts
@@ -18,6 +18,7 @@ import type {
 import { waitForDestinationChainTransaction } from '../waitForDestinationChainTransaction.js'
 import { getUTXOPublicClient } from './getUTXOPublicClient.js'
 import { parseUTXOErrors } from './parseUTXOErrors.js'
+import { isPsbtFinalized } from './utils.js'
 
 export interface UTXOStepExecutorOptions extends StepExecutorOptions {
   client: Client
@@ -278,14 +279,5 @@ export class UTXOStepExecutor extends BaseStepExecutor {
 
     // DONE
     return step
-  }
-}
-
-function isPsbtFinalized(psbt: Psbt): boolean {
-  try {
-    psbt.extractTransaction()
-    return true
-  } catch (_) {
-    return false
   }
 }

--- a/src/core/UTXO/UTXOStepExecutor.ts
+++ b/src/core/UTXO/UTXOStepExecutor.ts
@@ -183,7 +183,12 @@ export class UTXOStepExecutor extends BaseStepExecutor {
               ),
             }
           )
-          const signedPsbt = Psbt.fromHex(signedPsbtHex).finalizeAllInputs()
+
+          const signedPsbt = Psbt.fromHex(signedPsbtHex)
+
+          if (!isPsbtFinalized(signedPsbt)) {
+            signedPsbt.finalizeAllInputs()
+          }
 
           txHex = signedPsbt.extractTransaction().toHex()
 
@@ -273,5 +278,14 @@ export class UTXOStepExecutor extends BaseStepExecutor {
 
     // DONE
     return step
+  }
+}
+
+function isPsbtFinalized(psbt: Psbt): boolean {
+  try {
+    psbt.extractTransaction()
+    return true
+  } catch (_) {
+    return false
   }
 }

--- a/src/core/UTXO/utils.ts
+++ b/src/core/UTXO/utils.ts
@@ -1,0 +1,10 @@
+import type { Psbt } from 'bitcoinjs-lib'
+
+export function isPsbtFinalized(psbt: Psbt): boolean {
+  try {
+    psbt.extractTransaction()
+    return true
+  } catch (_) {
+    return false
+  }
+}


### PR DESCRIPTION
This PR:
 - adds a check for when a signedPSBT is already final