### PR TITLE
fix: add provider validation when fetching balances

### DIFF
--- a/src/services/balance.unit.spec.ts
+++ b/src/services/balance.unit.spec.ts
@@ -165,5 +165,27 @@ describe('Balance service tests', () => {
         expect(result).toEqual(balanceResponse)
       })
     })
+
+    describe('provider is not the same as the chain type', () => {
+      it('should return the tokens as is', async () => {
+        const balanceResponse = {
+          [ChainId.DAI]: [SOME_TOKEN],
+        }
+
+        mockedGetTokenBalancesForChains.mockReturnValue(
+          Promise.resolve(balanceResponse)
+        )
+
+        const result = await balance.getTokenBalancesByChain(
+          SOME_WALLET_ADDRESS,
+          {
+            [ChainId.DAI]: [SOME_TOKEN],
+          }
+        )
+
+        expect(mockedGetTokenBalancesForChains).toHaveBeenCalledTimes(1)
+        expect(result).toEqual(balanceResponse)
+      })
+    })
   })
 })


### PR DESCRIPTION
Adds validation to check whether the provider's type (from the wallet) matches the chain's type (of the tokens whose balances we need to fetch).