### PR TITLE
refactor(utxo): make bigmi chain id dynamic

### DIFF
--- a/src/core/UTXO/getUTXOPublicClient.ts
+++ b/src/core/UTXO/getUTXOPublicClient.ts
@@ -20,7 +20,7 @@ import {
 
 import { config } from '../../config.js'
 import { getRpcUrls } from '../rpc.js'
-import { lifiToBigmiChainId } from './utils.js'
+import { toBigmiChainId } from './utils.js'
 
 type PublicClient = Client<
   FallbackTransport<readonly HttpTransport[]>,
@@ -54,7 +54,7 @@ export const getUTXOPublicClient = async (
     const chain: Chain = {
       ..._chain,
       ..._chain.metamask,
-      id: lifiToBigmiChainId(_chain.id),
+      id: toBigmiChainId(_chain.id),
       name: _chain.metamask.chainName,
       rpcUrls: {
         default: { http: _chain.metamask.rpcUrls },

--- a/src/core/UTXO/getUTXOPublicClient.ts
+++ b/src/core/UTXO/getUTXOPublicClient.ts
@@ -1,26 +1,26 @@
-import type {
-  Account,
-  Chain,
-  Client,
-  FallbackTransport,
-  HttpTransport,
-  PublicActions,
-  UTXOSchema,
-  WalletActions,
-} from '@bigmi/core'
 import {
+  type Account,
   blockchair,
   blockcypher,
+  type Chain,
+  type Client,
   createClient,
+  type FallbackTransport,
   fallback,
+  type HttpTransport,
   http,
   mempool,
+  type PublicActions,
   publicActions,
   rpcSchema,
+  type UTXOSchema,
+  type WalletActions,
   walletActions,
 } from '@bigmi/core'
+
 import { config } from '../../config.js'
 import { getRpcUrls } from '../rpc.js'
+import { lifiToBigmiChainId } from './utils.js'
 
 type PublicClient = Client<
   FallbackTransport<readonly HttpTransport[]>,
@@ -54,6 +54,7 @@ export const getUTXOPublicClient = async (
     const chain: Chain = {
       ..._chain,
       ..._chain.metamask,
+      id: lifiToBigmiChainId(_chain.id),
       name: _chain.metamask.chainName,
       rpcUrls: {
         default: { http: _chain.metamask.rpcUrls },

--- a/src/core/UTXO/utils.ts
+++ b/src/core/UTXO/utils.ts
@@ -1,3 +1,5 @@
+import { ChainId as BigmiChainId } from '@bigmi/core'
+import { ChainId } from '@lifi/types'
 import type { Psbt } from 'bitcoinjs-lib'
 
 export function isPsbtFinalized(psbt: Psbt): boolean {
@@ -12,3 +14,12 @@ export function isPsbtFinalized(psbt: Psbt): boolean {
 // helper function to convert full public key (33 bytes) to x-only compressed format (32 bytes) required after taproot update
 export const toXOnly = (pubKey: Uint8Array) =>
   pubKey.length === 32 ? pubKey : pubKey.subarray(1, 33)
+
+export const lifiToBigmiChainId = (lifiChainId: ChainId): BigmiChainId => {
+  switch (lifiChainId) {
+    case ChainId.BTC:
+      return BigmiChainId.BITCOIN_MAINNET
+    default:
+      throw new Error(`Unsupported chainId mapping: ${lifiChainId}`)
+  }
+}

--- a/src/core/UTXO/utils.ts
+++ b/src/core/UTXO/utils.ts
@@ -15,11 +15,11 @@ export function isPsbtFinalized(psbt: Psbt): boolean {
 export const toXOnly = (pubKey: Uint8Array) =>
   pubKey.length === 32 ? pubKey : pubKey.subarray(1, 33)
 
-export const lifiToBigmiChainId = (lifiChainId: ChainId): BigmiChainId => {
-  switch (lifiChainId) {
+export const toBigmiChainId = (chainId: ChainId): BigmiChainId => {
+  switch (chainId) {
     case ChainId.BTC:
       return BigmiChainId.BITCOIN_MAINNET
     default:
-      throw new Error(`Unsupported chainId mapping: ${lifiChainId}`)
+      throw new Error(`Unsupported chainId mapping: ${chainId}`)
   }
 }


### PR DESCRIPTION
This PR decouples bigmi chain ids from LI.FI internal chain ids during bigmi client creation.

part of https://github.com/lifinance/bigmi/pull/31