### PR TITLE
utxo: add support for nested segwit addresses

### DIFF
--- a/src/core/UTXO/UTXOStepExecutor.ts
+++ b/src/core/UTXO/UTXOStepExecutor.ts
@@ -187,6 +187,7 @@ export class UTXOStepExecutor extends BaseStepExecutor {
                 })
               }
             }
+            // redeemScript: Required by Pay-to-Script-Hash (P2SH) addresses for proper spending
             if (addressInfo.type === AddressType.p2sh) {
               if (!input.redeemScript) {
                 const pubKey = this.client.account?.publicKey

--- a/src/core/UTXO/UTXOStepExecutor.ts
+++ b/src/core/UTXO/UTXOStepExecutor.ts
@@ -25,7 +25,7 @@ import type {
 import { waitForDestinationChainTransaction } from '../waitForDestinationChainTransaction.js'
 import { getUTXOPublicClient } from './getUTXOPublicClient.js'
 import { parseUTXOErrors } from './parseUTXOErrors.js'
-import { isPsbtFinalized, toXOnly } from './utils.js'
+import { generateRedeemScript, isPsbtFinalized, toXOnly } from './utils.js'
 
 interface UTXOStepExecutorOptions extends StepExecutorOptions {
   client: Client
@@ -185,6 +185,16 @@ export class UTXOStepExecutor extends BaseStepExecutor {
                 psbt.updateInput(index, {
                   sighashType: 1, // Default to Transaction.SIGHASH_ALL - 1
                 })
+              }
+            }
+            if (addressInfo.type === AddressType.p2sh) {
+              if (!input.redeemScript) {
+                const pubKey = this.client.account?.publicKey
+                if (pubKey) {
+                  psbt.updateInput(index, {
+                    redeemScript: generateRedeemScript(hexToUnit8Array(pubKey)),
+                  })
+                }
               }
             }
           })

--- a/src/core/UTXO/utils.ts
+++ b/src/core/UTXO/utils.ts
@@ -1,6 +1,6 @@
 import { ChainId as BigmiChainId } from '@bigmi/core'
 import { ChainId } from '@lifi/types'
-import type { Psbt } from 'bitcoinjs-lib'
+import { type Psbt, payments } from 'bitcoinjs-lib'
 
 export function isPsbtFinalized(psbt: Psbt): boolean {
   try {
@@ -23,3 +23,6 @@ export const toBigmiChainId = (chainId: ChainId): BigmiChainId => {
       throw new Error(`Unsupported chainId mapping: ${chainId}`)
   }
 }
+
+export const generateRedeemScript = (publicKey: Uint8Array) =>
+  payments.p2wpkh({ pubkey: publicKey }).output

--- a/src/core/UTXO/utils.ts
+++ b/src/core/UTXO/utils.ts
@@ -24,5 +24,11 @@ export const toBigmiChainId = (chainId: ChainId): BigmiChainId => {
   }
 }
 
+/**
+ * Generate redeem script for P2SH addresses
+ * @param publicKey
+ * @returns redeem script
+ */
 export const generateRedeemScript = (publicKey: Uint8Array) =>
+  // P2SH addresses are created by hashing the public key and using the result as the script
   payments.p2wpkh({ pubkey: publicKey }).output


### PR DESCRIPTION
closes https://lifi.atlassian.net/browse/LF-15679

### What was done
The `redeemScript` parameter required by transactions from nested segwit addresses is added.