### PR TITLE
feat: add approval reset for legacy tokens

### DIFF
--- a/src/core/EVM/EVMStepExecutor.ts
+++ b/src/core/EVM/EVMStepExecutor.ts
@@ -461,7 +461,7 @@ export class EVMStepExecutor extends BaseStepExecutor {
 
       switch (allowanceResult.status) {
         case 'BATCH_APPROVAL':
-          calls.push(allowanceResult.data.call)
+          calls.push(...allowanceResult.data.calls)
           signedTypedData = allowanceResult.data.signedTypedData
           break
         case 'NATIVE_PERMIT':

--- a/src/core/StatusManager.ts
+++ b/src/core/StatusManager.ts
@@ -183,6 +183,8 @@ export class StatusManager {
         step.execution.status = 'PENDING'
         currentProcess.pendingAt = Date.now()
         break
+      case 'RESET_REQUIRED':
+      case 'MESSAGE_REQUIRED':
       case 'ACTION_REQUIRED':
         step.execution.status = 'ACTION_REQUIRED'
         currentProcess.actionRequiredAt = Date.now()

--- a/src/core/processMessages.ts
+++ b/src/core/processMessages.ts
@@ -7,6 +7,9 @@ const processMessages: Record<
 > = {
   TOKEN_ALLOWANCE: {
     STARTED: 'Setting token allowance',
+    ACTION_REQUIRED: 'Set token allowance',
+    RESET_REQUIRED: 'Resetting token allowance',
+    MESSAGE_REQUIRED: 'Sign token allowance message',
     PENDING: 'Waiting for token allowance',
     DONE: 'Token allowance set',
   },

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -133,6 +133,7 @@ export type ProcessStatus =
   | 'STARTED'
   | 'ACTION_REQUIRED'
   | 'MESSAGE_REQUIRED'
+  | 'RESET_REQUIRED'
   | 'PENDING'
   | 'FAILED'
   | 'DONE'


### PR DESCRIPTION
## Which Jira task is linked to this PR?
[LF-15043](https://lifi.atlassian.net/browse/LF-15043)

## Why was it implemented this way?  
The current implementation uses a single pending status for both approval and revoke operations. This design introduces limitations in accurately distinguishing between the two states. The status handling should be refactored and made more granular in v4.

## Visual showcase (Screenshots or Videos)  

https://github.com/user-attachments/assets/6d41fe79-f19a-463e-9202-dcf516c4e49e

## Checklist before requesting a review  
- [x] I have performed a self-review and testing of my code.  
- [x] This pull request is focused and addresses a single problem.  
- [x] If this PR modifies the SDK API or adds new features that require documentation, I have updated the documentation in the [public-docs](https://github.com/lifinance/public-docs) repository.


[LF-15043]: https://lifi.atlassian.net/browse/LF-15043?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ