### PR TITLE
fix: disable EIP-2612 permits for tokens with non-ASCII names

### DIFF
--- a/src/core/EVM/EVMStepExecutor.ts
+++ b/src/core/EVM/EVMStepExecutor.ts
@@ -35,6 +35,7 @@ import type {
   TransactionMethodType,
   TransactionParameters,
 } from '../types.js'
+import { isTokenMessageSigningAllowed } from '../utils.js'
 import { waitForDestinationChainTransaction } from '../waitForDestinationChainTransaction.js'
 import { checkAllowance } from './checkAllowance.js'
 import { getActionWithFallback } from './getActionWithFallback.js'
@@ -423,7 +424,10 @@ export class EVMStepExecutor extends BaseStepExecutor {
     // Check if message signing is disabled - useful for smart contract wallets
     // We also disable message signing for custom steps
     const disableMessageSigning =
-      this.executionOptions?.disableMessageSigning || step.type !== 'lifi'
+      this.executionOptions?.disableMessageSigning ||
+      step.type !== 'lifi' ||
+      // We disable message signing for tokens with '₮' symbol
+      !isTokenMessageSigningAllowed(step.action.fromToken)
 
     // Check if chain has Permit2 contract deployed. Permit2 should not be available for atomic batch.
     const permit2Supported =

--- a/src/core/utils.ts
+++ b/src/core/utils.ts
@@ -1,4 +1,4 @@
-import type { LiFiStep } from '@lifi/types'
+import type { LiFiStep, Token } from '@lifi/types'
 
 // Standard threshold for destination amount difference (0.5%)
 const standardThreshold = 0.005
@@ -27,4 +27,16 @@ export function checkStepSlippageThreshold(
       1_000_000_000
   }
   return actualSlippage <= setSlippage
+}
+
+/**
+ * Checks whether a given token is eligible for message signing.
+ * Tokens with '₮' symbol in their name are disallowed,
+ * since such tokens may have non-standard signing requirements or compatibility issues with hardware wallets.
+ *
+ * @param token - The token object to check.
+ * @returns true if the token is allowed for message signing, false otherwise.
+ */
+export const isTokenMessageSigningAllowed = (token: Token): boolean => {
+  return !token.name?.includes('₮') && !token.symbol?.includes('₮')
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -83,6 +83,7 @@ export type {
 export type { UTXOProvider, UTXOProviderOptions } from './core/UTXO/types.js'
 export { isUTXO } from './core/UTXO/types.js'
 export { UTXO } from './core/UTXO/UTXO.js'
+export { isTokenMessageSigningAllowed as isTokenAllowedForMessageSigning } from './core/utils.js'
 export { createConfig } from './createConfig.js'
 export { BaseError } from './errors/baseError.js'
 export type { ErrorCode } from './errors/constants.js'


### PR DESCRIPTION
## Which Jira task is linked to this PR?  
[LF-16416](https://lifi.atlassian.net/browse/LF-16416)

## Why was it implemented this way?  
This PR disables permit usage for tokens whose contract name includes the ₮ character (specifically USD₮0) in the SDK.

Ledger devices currently freeze and crash when signing EIP-712 typed-data permits for this token due to the non-ASCII character in the name field. Since the domain name must match the on-chain token name exactly, we cannot safely normalize or replace the character client-side without breaking signature validation.

Temporary fix:
Fallback to standard approval flow for USD₮0 in the SDK to avoid hardware wallet signing failures.

Impact:
No functional change for non-affected tokens.
Users holding USD₮0 on supported chains will complete approvals via the standard approve transaction instead of permit.

We’ll re-enable permits once Ledger resolves Unicode support in typed-data signing.

## Checklist before requesting a review  
- [x] I have performed a self-review and testing of my code.  
- [x] This pull request is focused and addresses a single problem.  
- [x] If this PR modifies the SDK API or adds new features that require documentation, I have updated the documentation in the [public-docs](https://github.com/lifinance/public-docs) repository.


[LF-16416]: https://lifi.atlassian.net/browse/LF-16416?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ