### PR TITLE
feat(sdk): backport generic balance check to v3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lifi/sdk",
-  "version": "3.16.3",
+  "version": "3.17.0-beta.0",
   "description": "LI.FI Any-to-Any Cross-Chain-Swap SDK",
   "keywords": [
     "bridge",

--- a/src/core/EVM/getEVMBalance.ts
+++ b/src/core/EVM/getEVMBalance.ts
@@ -76,9 +76,18 @@ const getEVMBalanceMulticall = async (
   }
 
   return tokens.map((token, i: number) => {
+    const result = results[i]
+    if (result.status !== 'success') {
+      // RPC sub-call failed — leave amount undefined so callers can
+      // distinguish an unknown balance from a known zero.
+      return {
+        ...token,
+        blockNumber,
+      }
+    }
     return {
       ...token,
-      amount: results[i].result as bigint,
+      amount: result.result as bigint,
       blockNumber,
     }
   })

--- a/src/core/Solana/getSolanaBalance.int.spec.ts
+++ b/src/core/Solana/getSolanaBalance.int.spec.ts
@@ -75,12 +75,13 @@ describe.sequential('Solana token balance', async () => {
     )
     expect(tokenBalances.length).toBe(2)
 
-    // invalid tokens should be returned with balance 0
+    // A mint the wallet doesn't hold resolves to a known-zero balance
+    // (0n) when both Token and Token2022 program queries succeed.
     const invalidBalance = tokenBalances.find(
       (token) => token.address === invalidToken.address
     )
     expect(invalidBalance).toBeDefined()
-    expect(invalidBalance!.amount).toBeUndefined()
+    expect(invalidBalance!.amount).toBe(0n)
   })
 
   // it(

--- a/src/core/Solana/getSolanaBalance.ts
+++ b/src/core/Solana/getSolanaBalance.ts
@@ -76,15 +76,14 @@ const getSolanaBalanceDefault = async (
       ),
     ])
   const blockNumber = slot.status === 'fulfilled' ? BigInt(slot.value) : 0n
-  const solBalance = balance.status === 'fulfilled' ? BigInt(balance.value) : 0n
+  const nativeBalanceOk = balance.status === 'fulfilled'
+  const solBalance = nativeBalanceOk ? BigInt(balance.value) : 0n
+  const tokenProgramOk = tokenAccountsByOwner.status === 'fulfilled'
+  const token2022ProgramOk = token2022AccountsByOwner.status === 'fulfilled'
 
   const walletTokenAmounts = [
-    ...(tokenAccountsByOwner.status === 'fulfilled'
-      ? tokenAccountsByOwner.value.value
-      : []),
-    ...(token2022AccountsByOwner.status === 'fulfilled'
-      ? token2022AccountsByOwner.value.value
-      : []),
+    ...(tokenProgramOk ? tokenAccountsByOwner.value.value : []),
+    ...(token2022ProgramOk ? token2022AccountsByOwner.value.value : []),
   ].reduce(
     (tokenAmounts: Record<string, bigint>, value: any) => {
       const amount = BigInt(value.account.data.parsed.info.tokenAmount.amount)
@@ -96,19 +95,27 @@ const getSolanaBalanceDefault = async (
     {} as Record<string, bigint>
   )
 
-  walletTokenAmounts[SolSystemProgram] = solBalance
+  // We can only confidently report 0n for an SPL mint when both Token and
+  // Token2022 program queries succeeded — otherwise the mint may live in the
+  // program whose query failed (e.g. PYUSD on Token2022).
+  const splZeroIsKnown = tokenProgramOk && token2022ProgramOk
+
   const tokenAmounts: TokenAmount[] = tokens.map((token) => {
-    if (walletTokenAmounts[token.address]) {
-      return {
-        ...token,
-        amount: walletTokenAmounts[token.address],
-        blockNumber,
+    const isNative = token.address === SolSystemProgram
+    if (isNative) {
+      if (!nativeBalanceOk) {
+        return { ...token, blockNumber }
       }
+      return { ...token, amount: solBalance, blockNumber }
     }
-    return {
-      ...token,
-      blockNumber,
+    const found = walletTokenAmounts[token.address]
+    if (found !== undefined) {
+      return { ...token, amount: found, blockNumber }
     }
+    if (splZeroIsKnown) {
+      return { ...token, amount: 0n, blockNumber }
+    }
+    return { ...token, blockNumber }
   })
   return tokenAmounts
 }

--- a/src/core/Sui/getSuiBalance.int.spec.ts
+++ b/src/core/Sui/getSuiBalance.int.spec.ts
@@ -70,11 +70,12 @@ describe.sequential('Sui token balance', async () => {
     const tokenBalances = await getSuiBalance(walletAddress, tokens as Token[])
     expect(tokenBalances.length).toBe(2)
 
-    // invalid tokens should be returned with balance 0
+    // A coin type the wallet doesn't hold resolves to a known-zero
+    // balance (0n) when getAllBalances succeeds.
     const invalidBalance = tokenBalances.find(
       (token) => token.address === invalidToken.address
     )
     expect(invalidBalance).toBeDefined()
-    expect(invalidBalance!.amount).toBeUndefined()
+    expect(invalidBalance!.amount).toBe(0n)
   })
 })

--- a/src/core/Sui/getSuiBalance.ts
+++ b/src/core/Sui/getSuiBalance.ts
@@ -45,7 +45,8 @@ const getSuiBalanceDefault = async (
     ),
   ])
 
-  const coinsResult = coins.status === 'fulfilled' ? coins.value : []
+  const coinsOk = coins.status === 'fulfilled'
+  const coinsResult = coinsOk ? coins.value : []
   const blockNumber =
     checkpoint.status === 'fulfilled' ? BigInt(checkpoint.value) : 0n
 
@@ -70,17 +71,16 @@ const getSuiBalanceDefault = async (
   }
 
   const tokenAmounts: TokenAmount[] = tokens.map((token) => {
-    if (walletTokenAmounts[token.address]) {
-      return {
-        ...token,
-        amount: walletTokenAmounts[token.address],
-        blockNumber,
-      }
+    const found = walletTokenAmounts[token.address]
+    if (found !== undefined) {
+      return { ...token, amount: found, blockNumber }
     }
-    return {
-      ...token,
-      blockNumber,
+    if (coinsOk) {
+      // Wallet genuinely has no coins of this type.
+      return { ...token, amount: 0n, blockNumber }
     }
+    // RPC failed — leave amount undefined.
+    return { ...token, blockNumber }
   })
   return tokenAmounts
 }

--- a/src/core/UTXO/getUTXOBalance.ts
+++ b/src/core/UTXO/getUTXOBalance.ts
@@ -15,14 +15,26 @@ export const getUTXOBalance = async (
     }
   }
   const client = await getUTXOPublicClient(ChainId.BTC)
-  const [balance, blockCount] = await Promise.all([
+  const [balance, blockCount] = await Promise.allSettled([
     client.getBalance({ address: walletAddress }),
     client.getBlockCount(),
   ])
 
+  const blockNumber =
+    blockCount.status === 'fulfilled' ? BigInt(blockCount.value) : 0n
+
+  if (balance.status !== 'fulfilled') {
+    // RPC failed — leave amount undefined so callers can distinguish
+    // an unknown balance from a known zero.
+    return tokens.map((token) => ({
+      ...token,
+      blockNumber,
+    }))
+  }
+
   return tokens.map((token) => ({
     ...token,
-    amount: balance,
-    blockNumber: BigInt(blockCount),
+    amount: balance.value,
+    blockNumber,
   }))
 }

--- a/src/core/checkBalance.ts
+++ b/src/core/checkBalance.ts
@@ -1,45 +1,177 @@
-import type { LiFiStep } from '@lifi/types'
-import { formatUnits } from 'viem'
+import type { LiFiStep, Token, TokenAmount } from '@lifi/types'
+import { formatUnits, withTimeout } from 'viem'
+import { config } from '../config.js'
 import { BalanceError } from '../errors/errors.js'
-import { getTokenBalance } from '../services/balance.js'
 import { sleep } from '../utils/sleep.js'
 
+const MAX_ATTEMPTS = 6
+// Exponential backoff: 150, 300, 600, 1200, 2400 → ≈4.65s of sleep total.
+const BACKOFF_BASE_MS = 150
+const OVERALL_TIMEOUT_MS = 10_000
+const SLIPPAGE_PRECISION = 1_000_000_000n
+
+type Requirement = {
+  token: Token
+  sourcePart: bigint // 0n for pure overhead tokens
+  overheadPart: bigint // gas + non-included fees in this token
+}
+
+/**
+ * Verifies that the wallet holds enough of every token required to execute
+ * the step on its source chain — the source-token amount, any gas costs, and
+ * any non-included fee costs. Reads all balances in one batched provider
+ * call, retries within a bounded budget to absorb transient RPC failures and
+ * post-confirmation propagation lag, and applies slippage to the source-token
+ * portion only as a last resort (overhead is never trimmed).
+ *
+ * Throws BalanceError("The balance is too low.") on a genuine shortfall, or
+ * BalanceError("Could not read wallet balance.") if the balance can't be read
+ * after retries.
+ */
 export const checkBalance = async (
   walletAddress: string,
-  step: LiFiStep,
-  depth = 0
+  step: LiFiStep
 ): Promise<void> => {
-  const token = await getTokenBalance(walletAddress, step.action.fromToken)
-  if (token) {
-    const currentBalance = token.amount ?? 0n
-    const neededBalance = BigInt(step.action.fromAmount)
-
-    if (currentBalance < neededBalance) {
-      if (depth <= 3) {
-        await sleep(200)
-        await checkBalance(walletAddress, step, depth + 1)
-      } else if (
-        (neededBalance *
-          BigInt((1 - (step.action.slippage ?? 0)) * 1_000_000_000)) /
-          1_000_000_000n <=
-        currentBalance
-      ) {
-        // adjust amount in slippage limits
-        step.action.fromAmount = currentBalance.toString()
-      } else {
-        const needed = formatUnits(neededBalance, token.decimals)
-        const current = formatUnits(currentBalance, token.decimals)
-        let errorMessage = `Your ${token.symbol} balance is too low, you try to transfer ${needed} ${token.symbol}, but your wallet only holds ${current} ${token.symbol}. No funds have been sent.`
-
-        if (currentBalance !== 0n) {
-          errorMessage += `If the problem consists, please delete this transfer and start a new one with a maximum of ${current} ${token.symbol}.`
-        }
-
-        throw new BalanceError(
-          'The balance is too low.',
-          new Error(errorMessage)
-        )
-      }
+  const fromChainId = step.action.fromChainId
+  const requirements = new Map<string, Requirement>()
+  const add = (token: Token, amount: bigint, source: boolean): void => {
+    if (token.chainId !== fromChainId || amount === 0n) {
+      return
+    }
+    const key = token.address.toLowerCase()
+    const req = requirements.get(key) ?? {
+      token,
+      sourcePart: 0n,
+      overheadPart: 0n,
+    }
+    if (source) {
+      req.sourcePart += amount
+    } else {
+      req.overheadPart += amount
+    }
+    requirements.set(key, req)
+  }
+  add(step.action.fromToken, BigInt(step.action.fromAmount), true)
+  for (const gas of step.estimate?.gasCosts ?? []) {
+    add(gas.token, BigInt(gas.amount), false)
+  }
+  for (const fee of step.estimate?.feeCosts ?? []) {
+    // Included fees are already part of fromAmount — don't count twice.
+    if (!fee.included) {
+      add(fee.token, BigInt(fee.amount), false)
     }
   }
+  if (requirements.size === 0) {
+    return
+  }
+
+  // Provider is dispatched by wallet address; all requirements share the
+  // source chain, which matches this provider by virtue of the address.
+  const provider = config
+    .get()
+    .providers.find((p) => p.isAddress(walletAddress))
+  if (!provider) {
+    throw new Error(`SDK Token Provider for ${walletAddress} is not found.`)
+  }
+
+  const reqs = Array.from(requirements.values())
+  const tokens = reqs.map((r) => r.token)
+  const slippage = step.action.slippage ?? 0
+  const slippageScaled = BigInt(
+    Math.floor((1 - slippage) * Number(SLIPPAGE_PRECISION))
+  )
+
+  await withTimeout(
+    async () => {
+      for (let attempt = 0; attempt < MAX_ATTEMPTS; attempt++) {
+        const isFinal = attempt === MAX_ATTEMPTS - 1
+
+        let balances: TokenAmount[]
+        try {
+          balances = await provider.getBalance(walletAddress, tokens)
+        } catch (error) {
+          if (isFinal) {
+            throw new BalanceError(
+              'Could not read wallet balance.',
+              error as Error
+            )
+          }
+          await sleep(BACKOFF_BASE_MS * 2 ** attempt)
+          continue
+        }
+
+        const balanceByAddress = new Map(
+          balances.map((b) => [b.address.toLowerCase(), b.amount] as const)
+        )
+
+        const unknown: Token[] = []
+        const insufficient: { req: Requirement; have: bigint }[] = []
+        for (const req of reqs) {
+          const have = balanceByAddress.get(req.token.address.toLowerCase())
+          if (have === undefined) {
+            unknown.push(req.token)
+          } else if (have < req.sourcePart + req.overheadPart) {
+            insufficient.push({ req, have })
+          }
+        }
+
+        if (unknown.length === 0 && insufficient.length === 0) {
+          return
+        }
+
+        // Final-attempt slippage rescue: only when the sole shortfall is the
+        // source-token portion. Trim source down to (balance − overhead) so
+        // the overhead reserve is preserved.
+        if (
+          isFinal &&
+          unknown.length === 0 &&
+          insufficient.length === 1 &&
+          insufficient[0].req.sourcePart > 0n
+        ) {
+          const { req, have } = insufficient[0]
+          const minAcceptable =
+            (req.sourcePart * slippageScaled) / SLIPPAGE_PRECISION +
+            req.overheadPart
+          if (have >= minAcceptable) {
+            step.action.fromAmount = (have - req.overheadPart).toString()
+            return
+          }
+        }
+
+        if (isFinal) {
+          if (unknown.length > 0) {
+            throw new BalanceError(
+              'Could not read wallet balance.',
+              new Error(
+                `Could not read balance for: ${unknown
+                  .map((t) => t.symbol || t.address)
+                  .join(', ')}.`
+              )
+            )
+          }
+          const lines = insufficient.map(({ req, have }) => {
+            const needed = formatUnits(
+              req.sourcePart + req.overheadPart,
+              req.token.decimals
+            )
+            const current = formatUnits(have, req.token.decimals)
+            const symbol = req.token.symbol
+            return req.sourcePart > 0n
+              ? `Your ${symbol} balance is too low, you try to transfer ${needed} ${symbol}, but your wallet only holds ${current} ${symbol}.`
+              : `Insufficient ${symbol} for fees: need ${needed} ${symbol}, have ${current} ${symbol}.`
+          })
+          throw new BalanceError(
+            'The balance is too low.',
+            new Error(`${lines.join(' ')} No funds have been sent.`)
+          )
+        }
+
+        await sleep(BACKOFF_BASE_MS * 2 ** attempt)
+      }
+    },
+    {
+      timeout: OVERALL_TIMEOUT_MS,
+      errorInstance: new BalanceError('Could not read wallet balance.'),
+    }
+  )
 }

--- a/src/core/checkBalance.unit.spec.ts
+++ b/src/core/checkBalance.unit.spec.ts
@@ -1,0 +1,223 @@
+import type { LiFiStep, Token, TokenAmount } from '@lifi/types'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('../utils/sleep.js', () => ({
+  sleep: vi.fn(() => Promise.resolve(null)),
+}))
+
+let mockProviders: SDKProvider[] = []
+vi.mock('../config.js', () => ({
+  config: {
+    get: () => ({ providers: mockProviders }),
+  },
+}))
+
+import { LiFiErrorCode } from '../errors/constants.js'
+import { checkBalance } from './checkBalance.js'
+import type { SDKProvider } from './types.js'
+
+const SOURCE_CHAIN = 1
+
+const NATIVE_ETH: Token = {
+  chainId: SOURCE_CHAIN,
+  address: '0x0000000000000000000000000000000000000000',
+  symbol: 'ETH',
+  decimals: 18,
+  name: 'Ether',
+  priceUSD: '0',
+}
+
+const USDC: Token = {
+  chainId: SOURCE_CHAIN,
+  address: '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48',
+  symbol: 'USDC',
+  decimals: 6,
+  name: 'USD Coin',
+  priceUSD: '0',
+}
+
+const WALLET = '0xWalletAddress'
+
+type ProviderResultMap = { [address: string]: bigint | undefined }
+type AttemptScript = ProviderResultMap | 'reject'
+
+const setupProvider = (attempts: AttemptScript[]): ReturnType<typeof vi.fn> => {
+  let lastScript: AttemptScript = attempts[attempts.length - 1] ?? {}
+  const getBalance = vi.fn(async (_wallet: string, tokens: Token[]) => {
+    const next = attempts.shift()
+    const script = next ?? lastScript
+    if (next !== undefined) {
+      lastScript = next
+    }
+    if (script === 'reject') {
+      throw new Error('rpc reject')
+    }
+    return tokens.map((token) => {
+      const amount = (script as ProviderResultMap)[token.address.toLowerCase()]
+      if (amount === undefined) {
+        return { ...token } as TokenAmount
+      }
+      return { ...token, amount } as TokenAmount
+    })
+  })
+
+  const provider: SDKProvider = {
+    type: 'EVM' as any,
+    isAddress: (addr: string) => addr === WALLET,
+    resolveAddress: vi.fn(),
+    getStepExecutor: vi.fn(),
+    getBalance,
+  }
+
+  mockProviders = [provider]
+  return getBalance
+}
+
+const buildStep = (overrides: Partial<LiFiStep['action']> = {}): LiFiStep => {
+  const action = {
+    fromChainId: SOURCE_CHAIN,
+    fromAmount: '1000000', // 1 USDC
+    fromToken: USDC,
+    toChainId: SOURCE_CHAIN,
+    toToken: USDC,
+    slippage: 0.005,
+    ...overrides,
+  }
+  return {
+    type: 'lifi',
+    id: 'step-1',
+    tool: 'lifi',
+    toolDetails: { key: 'lifi', name: 'LI.FI', logoURI: '' },
+    action,
+    estimate: {
+      tool: 'lifi',
+      fromAmount: action.fromAmount,
+      toAmount: action.fromAmount,
+      toAmountMin: action.fromAmount,
+      approvalAddress: '0x0',
+      executionDuration: 30,
+      gasCosts: [],
+      feeCosts: [],
+    },
+    includedSteps: [],
+  } as unknown as LiFiStep
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  vi.restoreAllMocks()
+})
+
+describe('checkBalance — source token', () => {
+  it('passes when balance >= source amount and no overhead', async () => {
+    setupProvider([{ [USDC.address.toLowerCase()]: 1_000_000n }])
+    await expect(checkBalance(WALLET, buildStep())).resolves.toBeUndefined()
+  })
+
+  it('throws BalanceError("balance is too low") when persistently insufficient', async () => {
+    setupProvider(Array(6).fill({ [USDC.address.toLowerCase()]: 0n }))
+    await expect(checkBalance(WALLET, buildStep())).rejects.toMatchObject({
+      code: LiFiErrorCode.BalanceError,
+      message: 'The balance is too low.',
+    })
+  })
+
+  it('absorbs transient low balance and resolves on a later attempt', async () => {
+    const getBalance = setupProvider([
+      { [USDC.address.toLowerCase()]: 0n },
+      { [USDC.address.toLowerCase()]: 0n },
+      { [USDC.address.toLowerCase()]: 1_000_000n },
+    ])
+    await expect(checkBalance(WALLET, buildStep())).resolves.toBeUndefined()
+    expect(getBalance).toHaveBeenCalledTimes(3)
+  })
+
+  it('adjusts source amount within slippage on the final attempt', async () => {
+    const step = buildStep({ slippage: 0.005, fromAmount: '1000000' })
+    setupProvider(Array(6).fill({ [USDC.address.toLowerCase()]: 996_000n }))
+    await expect(checkBalance(WALLET, step)).resolves.toBeUndefined()
+    expect(step.action.fromAmount).toBe('996000')
+  })
+
+  it('does not adjust when below slippage tolerance', async () => {
+    const step = buildStep({ slippage: 0.005, fromAmount: '1000000' })
+    setupProvider(Array(6).fill({ [USDC.address.toLowerCase()]: 990_000n }))
+    await expect(checkBalance(WALLET, step)).rejects.toMatchObject({
+      code: LiFiErrorCode.BalanceError,
+      message: 'The balance is too low.',
+    })
+    expect(step.action.fromAmount).toBe('1000000')
+  })
+})
+
+describe('checkBalance — overhead tokens', () => {
+  it('verifies native gas balance when source token != native', async () => {
+    const step = buildStep()
+    step.estimate!.gasCosts = [
+      {
+        type: 'SUM',
+        price: '0',
+        estimate: '0',
+        limit: '0',
+        amount: '5000000000000000',
+        amountUSD: '0',
+        token: NATIVE_ETH,
+      },
+    ] as any
+    setupProvider([
+      {
+        [USDC.address.toLowerCase()]: 1_000_000n,
+        [NATIVE_ETH.address.toLowerCase()]: 1_000_000_000_000_000n,
+      },
+    ])
+    await expect(checkBalance(WALLET, step)).rejects.toMatchObject({
+      code: LiFiErrorCode.BalanceError,
+      message: 'The balance is too low.',
+    })
+  })
+
+  it('does not double-count fees flagged as included', async () => {
+    const step = buildStep()
+    step.estimate!.feeCosts = [
+      {
+        name: 'fee',
+        description: '',
+        percentage: '0',
+        token: USDC,
+        amount: '500000',
+        amountUSD: '0',
+        included: true,
+      },
+    ]
+    setupProvider([{ [USDC.address.toLowerCase()]: 1_000_000n }])
+    await expect(checkBalance(WALLET, step)).resolves.toBeUndefined()
+  })
+})
+
+describe('checkBalance — RPC failures', () => {
+  it('throws "Could not read wallet balance" when provider rejects every attempt', async () => {
+    setupProvider(Array(6).fill('reject') as AttemptScript[])
+    await expect(checkBalance(WALLET, buildStep())).rejects.toMatchObject({
+      code: LiFiErrorCode.BalanceError,
+      message: 'Could not read wallet balance.',
+    })
+  })
+
+  it('throws "Could not read wallet balance" when amount stays unknown', async () => {
+    setupProvider(Array(6).fill({ [USDC.address.toLowerCase()]: undefined }))
+    await expect(checkBalance(WALLET, buildStep())).rejects.toMatchObject({
+      code: LiFiErrorCode.BalanceError,
+      message: 'Could not read wallet balance.',
+    })
+  })
+
+  it('absorbs transient RPC failure and resolves on a later attempt', async () => {
+    const getBalance = setupProvider([
+      'reject',
+      'reject',
+      { [USDC.address.toLowerCase()]: 1_000_000n },
+    ])
+    await expect(checkBalance(WALLET, buildStep())).resolves.toBeUndefined()
+    expect(getBalance).toHaveBeenCalledTimes(3)
+  })
+})

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,2 +1,2 @@
 export const name = '@lifi/sdk'
-export const version = '3.16.3'
+export const version = '3.17.0-beta.0'


### PR DESCRIPTION
## Which Linear task is linked to this PR?

[EMB-334](https://linear.app/lifi-linear/issue/EMB-334)

## Why was it implemented this way?

Backport of #372 (v4 main) to the v3 branch. Same logic, adapted for v3's architecture:

- Single-package monorepo (no separate provider packages)
- No `SDKClient` abstraction — uses `config.get().providers` for dispatch
- Provider `getBalance(walletAddress, tokens)` (no `client` param)
- `withTimeout` imported from `viem` (already a dependency), not a custom utility
- `formatUnits` from `viem` (v3 convention)

### What changed

**Core (`src/core/checkBalance.ts`)** — rewritten to verify source amount + gas costs + non-included fees on the source chain. Bounded retry (6 attempts, exponential backoff, 10s outer timeout). Slippage applies to source-token portion only; overhead is never trimmed.

**Providers** — each balance reader now distinguishes "known zero" (`0n`) from "unknown" (`undefined`):
- EVM (`src/core/EVM/getEVMBalance.ts`): multicall sub-call failure → undefined
- Solana (`src/core/Solana/getSolanaBalance.ts`): per-program ok flags; only report `0n` when both Token and Token2022 queries succeeded
- UTXO (`src/core/UTXO/getUTXOBalance.ts`): `Promise.allSettled`; omit amount on RPC failure
- Sui (`src/core/Sui/getSuiBalance.ts`): distinguish `getAllBalances` rejection from "no coins"

### Out of scope (same as v4 PR)

- Thread `AbortSignal` through provider RPC calls
- Opt-in lenient mode for overhead tokens
- Cancellation of in-flight balance check

## Visual showcase (Screenshots or Videos)

N/A — backend logic change.

## Checklist before requesting a review
- [x] I have performed a self-review and testing of my code.
- [x] This pull request is focused and addresses a single problem.
- [ ] If this PR modifies the SDK API or adds new features that require documentation, I have updated the documentation in the [public-docs](https://github.com/lifinance/public-docs) repository.

### Test plan

- [x] `pnpm check:types` — green
- [x] `pnpm check` — green
- [x] `pnpm test .unit.spec.ts` — 118 passing (10 new checkBalance tests)
- [x] EVM int test — 6/6 passed
- [x] UTXO int test — 1/1 passed
- [x] Sui int test — 3/3 passed
- [x] Solana int test — 3/3 passed (429 rate-limiting on retry, eventually succeeded)