### PR TITLE
chore: remove deprecated code

### DIFF
--- a/packages/sdk-provider-ethereum/src/types.ts
+++ b/packages/sdk-provider-ethereum/src/types.ts
@@ -86,10 +86,6 @@ export interface ApproveTokenRequest {
   token: BaseToken
   spenderAddress: string
   amount: bigint
-  /**
-   * @deprecated
-   */
-  infiniteApproval?: boolean
 }
 
 export interface RevokeApprovalRequest {

--- a/packages/sdk/src/types/core.ts
+++ b/packages/sdk/src/types/core.ts
@@ -205,10 +205,6 @@ export interface ExecutionOptions {
   getContractCalls?: GetContractCallsHook
   adjustZeroOutputFromPreviousStep?: boolean
   executeInBackground?: boolean
-  /**
-   * @deprecated
-   */
-  infiniteApproval?: boolean
 }
 
 export type ExecutionStatus = 'ACTION_REQUIRED' | 'PENDING' | 'FAILED' | 'DONE'


### PR DESCRIPTION
## Which Linear task is linked to this PR? 
https://linear.app/lifi-linear/issue/EMB-159/remove-deprecated-code-from-the-sdk

## Why was it implemented this way?  
Both fields have been carrying a `@deprecated` JSDoc tag for some time with no remaining consumers.

- `ExecutionOptions.infiniteApproval` in `@lifi/sdk`
- `ApproveTokenRequest.infiniteApproval` in `@lifi/sdk-provider-ethereum`

## Visual showcase (Screenshots or Videos)  
N/A — type-only change.

## Checklist before requesting a review  
- [x] I have performed a self-review and testing of my code.  
- [x] This pull request is focused and addresses a single problem.  
- [ ] If this PR modifies the SDK API or adds new features that require documentation, I have updated the documentation in the [public-docs](https://github.com/lifinance/public-docs) repository.