### PR TITLE
fix(sdk-provider-solana): balance aggregation, confirmation races, and RPC ordering

### DIFF
--- a/packages/sdk-provider-solana/src/actions/getSolanaBalance.ts
+++ b/packages/sdk-provider-solana/src/actions/getSolanaBalance.ts
@@ -115,7 +115,8 @@ const getSolanaBalanceDefault = async (
         value.account.data.parsed.info
       const amount = BigInt(tokenAccount.tokenAmount.amount)
       if (amount > 0n) {
-        tokenAmounts[tokenAccount.mint] = amount
+        tokenAmounts[tokenAccount.mint] =
+          (tokenAmounts[tokenAccount.mint] ?? 0n) + amount
       }
       return tokenAmounts
     },

--- a/packages/sdk-provider-solana/src/actions/sendAndConfirmBundle.ts
+++ b/packages/sdk-provider-solana/src/actions/sendAndConfirmBundle.ts
@@ -23,6 +23,10 @@ export type BundleResult = {
   signatureResults: (SignatureStatus | null)[]
 }
 
+const NULL_BUNDLE_RESULT = new Error(
+  'Bundle was not confirmed by this RPC'
+)
+
 /**
  * Send and confirm a bundle of transactions using Jito.
  * Automatically selects a Jito-enabled RPC connection and polls for confirmation
@@ -135,7 +139,15 @@ export async function sendAndConfirmBundle(
   })
 
   // Wait for first successful confirmation
-  const result = await Promise.any(confirmPromises).catch(() => null)
+  const result = await Promise.any(
+    confirmPromises.map(async (promise) => {
+      const bundleResult = await promise
+      if (!bundleResult) {
+        throw NULL_BUNDLE_RESULT
+      }
+      return bundleResult
+    })
+  ).catch(() => null)
 
   if (!abortController.signal.aborted) {
     abortController.abort()

--- a/packages/sdk-provider-solana/src/actions/sendAndConfirmTransaction.ts
+++ b/packages/sdk-provider-solana/src/actions/sendAndConfirmTransaction.ts
@@ -21,6 +21,10 @@ type ConfirmedTransactionResult = {
   txSignature: string
 }
 
+const NULL_CONFIRMATION_RESULT = new Error(
+  'Transaction was not confirmed by this RPC'
+)
+
 /**
  * Sends a Solana transaction to multiple RPC endpoints and returns the confirmation
  * as soon as any of them confirm the transaction.
@@ -145,7 +149,15 @@ export async function sendAndConfirmTransaction(
     }
   })
 
-  const signatureResult = await Promise.any(confirmPromises).catch(() => null)
+  const signatureResult = await Promise.any(
+    confirmPromises.map(async (promise) => {
+      const result = await promise
+      if (!result) {
+        throw NULL_CONFIRMATION_RESULT
+      }
+      return result
+    })
+  ).catch(() => null)
 
   if (!abortController.signal.aborted) {
     abortController.abort()

--- a/packages/sdk-provider-solana/src/core/tasks/SolanaJitoWaitForTransactionTask.ts
+++ b/packages/sdk-provider-solana/src/core/tasks/SolanaJitoWaitForTransactionTask.ts
@@ -31,6 +31,13 @@ export class SolanaJitoWaitForTransactionTask extends BaseStepExecutionTask {
       )
     }
 
+    if (!signedTransactions.length) {
+      throw new TransactionError(
+        LiFiErrorCode.TransactionUnprepared,
+        'Unable to prepare transaction. Signed transactions are not found.'
+      )
+    }
+
     // Use Jito bundle for transaction submission
     const bundleResult = await sendAndConfirmBundle(client, signedTransactions)
 

--- a/packages/sdk-provider-solana/src/rpc/registry.ts
+++ b/packages/sdk-provider-solana/src/rpc/registry.ts
@@ -23,26 +23,28 @@ export const isJitoRpc = async (rpcUrl: string): Promise<boolean> => {
  * Initializes Solana RPCs for all available RPC URLs if they haven't been cached yet.
  * @param client - The SDK client used to fetch RPC URLs.
  */
-const ensureSolanaRpcs = async (client: SDKClient): Promise<void> => {
+const ensureSolanaRpcs = async (client: SDKClient): Promise<string[]> => {
   const rpcUrls = await client.getRpcUrlsByChainId(ChainId.SOL)
   for (const rpcUrl of rpcUrls) {
     if (!solanaRpcs.has(rpcUrl)) {
       solanaRpcs.set(rpcUrl, createSolanaRpc(rpcUrl))
     }
   }
+  return rpcUrls
 }
 
 /**
  * Detects and caches Jito-capable RPCs by checking if they support the getTipAccounts method.
  * @param client - The SDK client used to fetch RPC URLs.
  */
-const ensureJitoRpcs = async (client: SDKClient): Promise<void> => {
+const ensureJitoRpcs = async (client: SDKClient): Promise<string[]> => {
   const rpcUrls = await client.getRpcUrlsByChainId(ChainId.SOL)
   for (const rpcUrl of rpcUrls) {
     if (!jitoRpcs.has(rpcUrl) && (await isJitoRpc(rpcUrl))) {
       jitoRpcs.set(rpcUrl, createJitoRpc(rpcUrl))
     }
   }
+  return rpcUrls
 }
 
 /**
@@ -52,8 +54,10 @@ const ensureJitoRpcs = async (client: SDKClient): Promise<void> => {
 export const getSolanaRpcs = async (
   client: SDKClient
 ): Promise<SolanaRpcType[]> => {
-  await ensureSolanaRpcs(client)
-  return Array.from(solanaRpcs.values())
+  const rpcUrls = await ensureSolanaRpcs(client)
+  return rpcUrls
+    .map((rpcUrl) => solanaRpcs.get(rpcUrl))
+    .filter((rpc): rpc is SolanaRpcType => Boolean(rpc))
 }
 
 /**
@@ -63,6 +67,8 @@ export const getSolanaRpcs = async (
 export const getJitoRpcs = async (
   client: SDKClient
 ): Promise<JitoRpcType[]> => {
-  await ensureJitoRpcs(client)
-  return Array.from(jitoRpcs.values())
+  const rpcUrls = await ensureJitoRpcs(client)
+  return rpcUrls
+    .map((rpcUrl) => jitoRpcs.get(rpcUrl))
+    .filter((rpc): rpc is JitoRpcType => Boolean(rpc))
 }


### PR DESCRIPTION
 ## Summary
                                                                                                                                                                                                                                                                                              
  A handful of correctness bugs in `@lifi/sdk-provider-solana`:                                                                                                                                                                                                                               
                                                                                                                                                                                                                                                                                              
  - **`getSolanaBalance`** — `tokenAmounts[mint] = amount` overwrote earlier entries, so wallets with multiple token accounts for the same mint (common for USDC) had balances reported as the last-seen account only. Now sums them. Also only reports `0n` for an SPL mint when **both** the
   Token and Token-2022 program queries succeeded, since a mint may live in whichever program's query failed (e.g. PYUSD on Token-2022).
  - **`sendAndConfirmTransaction` / `sendAndConfirmBundle`** — `Promise.any(promises).catch(() => null)` was being fed promises that could fulfil with `null` on a per-RPC timeout. Because `null` is a fulfilled value, `Promise.any` resolved to `null` as soon as the first RPC gave up,   
  discarding valid confirmations from slower RPCs. The inner map now throws a sentinel on `null`, so `Promise.any` skips it and waits for a real confirmation (or rejects once every RPC has given up).                                                                                       
  - **`SolanaJitoWaitForTransactionTask`** — empty `signedTransactions` now throws `TransactionUnprepared` before we call `sendAndConfirmBundle`, matching the guard already present in `SolanaStandardWaitForTransactionTask`.
  - **`rpc/registry.ts`** — `getSolanaRpcs` / `getJitoRpcs` returned `Array.from(map.values())`, which ignored the URL order from `client.getRpcUrlsByChainId`. `callWithRetry` iterates in array order, so retries were effectively random across runs. Both functions now derive the list from the URL array and filter out entries lost to LRU eviction.  

## Checklist before requesting a review  
- [x] I have performed a self-review and testing of my code.  
- [ ] This pull request is focused and addresses a single problem.  
- [ ] If this PR modifies the SDK API or adds new features that require documentation, I have updated the documentation in the [public-docs](https://github.com/lifinance/public-docs) repository.
