### PR TITLE
fix(sdk-provider-solana): accept undefined for unheld mint in int test

### DIFF
--- a/packages/sdk-provider-solana/src/actions/getSolanaBalance.int.spec.ts
+++ b/packages/sdk-provider-solana/src/actions/getSolanaBalance.int.spec.ts
@@ -83,13 +83,19 @@ describe.sequential('Solana token balance', async () => {
     )
     expect(tokenBalances.length).toBe(2)
 
-    // A mint the wallet doesn't hold resolves to a known-zero balance
-    // (0n) when both Token and Token2022 program queries succeed.
+    // Post-#372 contract: a mint the wallet doesn't hold is reported as a
+    // known zero (`0n`) when both Token and Token2022 program queries
+    // succeed, and as unknown (`undefined`) when either query was rejected
+    // (rate-limit / RPC flake). Both are valid graceful-degradation
+    // outcomes for "invalid data" — assert that we got one of them and
+    // didn't crash.
     const invalidBalance = tokenBalances.find(
       (token) => token.address === invalidToken.address
     )
     expect(invalidBalance).toBeDefined()
-    expect(invalidBalance!.amount).toBe(0n)
+    expect(
+      invalidBalance!.amount === 0n || invalidBalance!.amount === undefined
+    ).toBe(true)
   })
 
   // it(


### PR DESCRIPTION
## Which Linear task is linked to this PR?
None — small CI flake fix, surfaced on #377.

## Why was it implemented this way?
PR #372 (`feat(sdk): generic balance check with native fee + rent coverage`) tightened `getSolanaBalance` so an SPL mint the wallet doesn't hold is reported as `0n` **only** when both Token and Token-2022 program queries succeed; if either query is rejected (rate-limit / RPC flake), the balance is reported as `undefined` ("unknown") so a partially-failed read can't masquerade as a known zero.

The int test fixture (`should return even with invalid data`) had its assertion tightened to `expect(invalidBalance!.amount).toBe(0n)` in the same PR, but the test wallet (`9T655zHa6bYrTHWdy59NFqkjwoaSwfMat2yzixE1nb56`) hits live mainnet RPCs whose rate-limiting flips the outcome between the two valid branches — CI for #377 observed `undefined` after a Token-program rejection.

Both outcomes are correct graceful-degradation behavior. Loosen the assertion to accept either, and update the comment to describe the actual contract.

## Visual showcase (Screenshots or Videos)
N/A — int test assertion change only.

## Checklist before requesting a review
- [x] I have performed a self-review and testing of my code.
- [x] This pull request is focused and addresses a single problem.
- [ ] If this PR modifies the SDK API or adds new features that require documentation, I have updated the documentation in the [public-docs](https://github.com/lifinance/public-docs) repository.

### Test plan
- [x] `pnpm check` — green
- [x] `pnpm check:types` — green
- [x] `pnpm --filter @lifi/sdk-provider-solana test` — `should return even with invalid data` no longer flakes between `0n` / `undefined`