### PR TITLE
fix(sdk): sync includedSteps[0].fromAmount in checkBalance slippage rescue

### DIFF
--- a/packages/sdk/src/core/tasks/helpers/checkBalance.ts
+++ b/packages/sdk/src/core/tasks/helpers/checkBalance.ts
@@ -165,7 +165,11 @@ export const checkBalance = async (
           const minAcceptable =
             (req.sourcePart * slippageScaled) / SLIPPAGE_PRECISION + reserved
           if (have >= minAcceptable) {
-            step.action.fromAmount = (have - reserved).toString()
+            const newFromAmount = (have - reserved).toString()
+            step.action.fromAmount = newFromAmount
+            if (step.includedSteps?.length) {
+              step.includedSteps[0].action.fromAmount = newFromAmount
+            }
             return
           }
         }


### PR DESCRIPTION
## Which Linear task is linked to this PR?

[EMB-353](https://linear.app/lifi-linear/issue/EMB-353/checkbalance-leaves-includedsteps-fromamount-stale-in-rescue-path)

## Why was it implemented this way?

Slippage rescue trimmed `step.action.fromAmount` but left `step.includedSteps[0].action.fromAmount` stale. `/advanced/stepTransaction` enforces equality between the two via Ajv — causing a 400 for integrators whenever the rescue path fires on a lifi-typed step.

Mirrors the sync already in `execution.ts:104-108`.

## Visual showcase (Screenshots or Videos)

N/A — internal logic fix, no UI changes.

## Checklist before requesting a review
- [x] I have performed a self-review and testing of my code.
- [x] This pull request is focused and addresses a single problem.
- [x] If this PR modifies the SDK API or adds new features that require documentation, I have updated the documentation in the [public-docs](https://github.com/lifinance/public-docs) repository.