### PR TITLE
fix: disable pnpm confirmModulesPurge for non-interactive environments

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,5 +1,6 @@
 packages:
   - packages/*
+confirmModulesPurge: false
 allowBuilds:
   msw: true
   nx: true


### PR DESCRIPTION
## Which Linear task is linked to this PR?

https://linear.app/lifi-linear/issue/EMB-380/pnpm-11-pre-push-hook-fails-without-tty-when-lockfile-changes

## Why was it implemented this way?

pnpm 11 added a safety prompt that requires TTY confirmation before purging `node_modules`. Git hooks run without a TTY, so pnpm aborts with `ERR_PNPM_ABORTED_REMOVE_MODULES_DIR_NO_TTY` whenever the lockfile changes (e.g. after rebase/pull from main).

`confirmModulesPurge: false` in `pnpm-workspace.yaml` is the pnpm-recommended setting for non-interactive environments — it skips the confirmation and proceeds with the purge automatically.

**How to reproduce:**
1. Work on a feature branch
2. Rebase onto main where the lockfile has changed
3. Run `git push` — pre-push hook fails

## Visual showcase (Screenshots or Videos)

N/A

## Checklist before requesting a review
- [x] I have performed a self-review and testing of my code.
- [x] This pull request is focused and addresses a single problem.
- [ ] If this PR modifies the SDK API or adds new features that require documentation, I have updated the documentation in the [public-docs](https://github.com/lifinance/public-docs) repository.