### PR TITLE
fix: preserve Solana simulation details

### DIFF
--- a/packages/sdk-provider-solana/src/core/tasks/SolanaStandardWaitForTransactionTask.ts
+++ b/packages/sdk-provider-solana/src/core/tasks/SolanaStandardWaitForTransactionTask.ts
@@ -60,16 +60,23 @@ export class SolanaStandardWaitForTransactionTask extends BaseStepExecutionTask 
       )
 
       if (simulationResult.value.err) {
+        const simulationErrorDetails = {
+          err: simulationResult.value.err,
+          logs: simulationResult.value.logs,
+        }
         const errorMessage =
           typeof simulationResult.value.err === 'object'
             ? JSON.stringify(simulationResult.value.err, (_, v) =>
                 typeof v === 'bigint' ? v.toString() : v
               )
             : simulationResult.value.err
+        const simulationError = new Error(errorMessage, {
+          cause: simulationErrorDetails,
+        })
         throw new TransactionError(
           LiFiErrorCode.TransactionSimulationFailed,
           `Transaction simulation failed: ${errorMessage}`,
-          new Error(errorMessage)
+          simulationError
         )
       }
     }


### PR DESCRIPTION
## Summary
- include Solana simulation `err` and `logs` on the error cause when preflight simulation fails
- keep the existing human-readable `Transaction simulation failed: ...` message unchanged
- preserve bigint-safe JSON formatting for the top-level message

## Why
This addresses #385. Consumers currently receive code `1019` but lose the detailed Solana simulation result, so they have to re-simulate the transaction to diagnose the failure. Passing the details through the cause keeps the public message readable while making the original simulation payload inspectable.

## Testing
- `corepack pnpm install --frozen-lockfile --ignore-scripts`
- `corepack pnpm --filter @lifi/sdk build`
- `corepack pnpm --filter @lifi/sdk-provider-solana check:types`
- `corepack pnpm --dir packages/sdk-provider-solana test .unit.spec.ts --passWithNoTests`
- `corepack pnpm --filter @lifi/sdk-provider-solana build`
- `git diff --check`
