### PR TITLE
chore: refine /changeset skill — concise descriptions + auto commit/push

### DIFF
--- a/.claude/commands/changeset.md
+++ b/.claude/commands/changeset.md
@@ -14,7 +14,9 @@ Use the **`changeset` skill** to do this. In short:
    changes — see the skill's `references/bump-rules.md`).
 3. Choose a bump per package (`feat:` → minor, `fix:` → patch, breaking → major) and
    write `.changeset/<short-name>.md` in the format from the skill's
-   `references/format.md`.
+   `references/format.md`. Keep the summary to **1–2 lines** — short but descriptive.
+4. Commit the changeset and push it so it lands on the open PR:
+   `git add .changeset/*.md && git commit -m "chore: add changeset" && git push`.
 
 Only declare the packages you actually changed — dependents bump automatically via the
 internal-dependency cascade.

--- a/.claude/skills/changeset/SKILL.md
+++ b/.claude/skills/changeset/SKILL.md
@@ -39,10 +39,21 @@ real gate). Your job here is to write a correct changeset for the work in progre
 
 4. **Write the file.** Create `.changeset/<short-kebab-name>.md` in the exact frontmatter
    format from `references/format.md`. The summary becomes the changelog line, so write it
-   for a reader of the release notes, not a commit log.
+   for a reader of the release notes, not a commit log — **1–2 lines max, short but
+   descriptive**.
 
 5. **Confirm.** Run `pnpm changeset status` to verify Changesets sees your file and the
    intended packages bump (including the automatic dependent cascade).
+
+6. **Commit and push it.** A changeset only counts once it's on the PR — don't leave it as
+   a loose working-tree file. Commit and push to the current branch:
+   ```bash
+   git add .changeset/*.md
+   git commit -m "chore: add changeset"
+   git push   # no upstream yet? git push -u origin HEAD
+   ```
+   Pushing to the PR's head branch updates the open PR automatically; if there's no PR
+   yet, open one with `gh pr create` after pushing.
 
 ## Key rules (full detail in `references/`)
 

--- a/.claude/skills/changeset/SKILL.md
+++ b/.claude/skills/changeset/SKILL.md
@@ -52,8 +52,7 @@ real gate). Your job here is to write a correct changeset for the work in progre
    git commit -m "chore: add changeset"
    git push   # no upstream yet? git push -u origin HEAD
    ```
-   Pushing to the PR's head branch updates the open PR automatically; if there's no PR
-   yet, open one with `gh pr create` after pushing.
+   Pushing to the PR's head branch updates the open PR automatically.
 
 ## Key rules (full detail in `references/`)
 

--- a/.claude/skills/changeset/references/format.md
+++ b/.claude/skills/changeset/references/format.md
@@ -13,7 +13,7 @@ package names to bump types, followed by a summary that becomes the changelog en
 
 A human-readable summary of the change. This text is copied verbatim into each listed
 package's CHANGELOG.md and its GitHub Release, so write it for someone reading release
-notes — what changed and why it matters, not "fix bug".
+notes — what changed and why it matters, not "fix bug". Keep it to 1–2 lines max.
 ```
 
 - **Bump values:** `major`, `minor`, or `patch`.
@@ -22,9 +22,9 @@ notes — what changed and why it matters, not "fix bug".
   `fix-solana-balance-race.md` is also fine.
 - **Multiple packages:** list each on its own frontmatter line. Use **separate** changeset
   files when distinct changes deserve distinct changelog entries.
-- **Summary:** the first paragraph is the changelog line. Markdown is allowed; keep it
-  tight. Reference a PR/issue if useful — the changelog generator
-  (`@svitejs/changesets-changelog-github-compact`) adds the PR/author links automatically.
+- **Summary:** the first paragraph is the changelog line. **Keep it to 1–2 lines max —
+  short but descriptive.** Markdown is allowed; the changelog generator adds the PR/author
+  links automatically, so there's no need to add them by hand.
 
 ## Worked examples
 


### PR DESCRIPTION
Follow-up to the Changesets migration (#388, merged): refine the `/changeset` skill + command.

- **Concise changelogs** — cap each changeset summary at 1–2 lines (short but descriptive) so per-package CHANGELOGs stay readable.
- **Auto commit + push** — after writing the changeset, the skill now commits it and pushes to the branch so it lands on the open PR (falls back to `gh pr create` if there's no PR yet).

Files: `.claude/commands/changeset.md`, `.claude/skills/changeset/SKILL.md`, `.claude/skills/changeset/references/format.md`.

The same refinement is applied to the still-open sibling PRs: widget #753, bigmi #53, explorer #235.