### PR TITLE
test: validate preview-publish lockfile fix (do not merge)

### DIFF
--- a/.changeset/zz-test-preview-deps-fix.md
+++ b/.changeset/zz-test-preview-deps-fix.md
@@ -1,0 +1,5 @@
+---
+"@lifi/sdk-provider-tron": patch
+---
+
+TEST ONLY — validates the preview-publish lockfile fix. Remove before merging.

--- a/.github/actions/preview-publish/action.yml
+++ b/.github/actions/preview-publish/action.yml
@@ -48,7 +48,9 @@ runs:
     - name: Publish preview to npm
       if: steps.detect.outputs.publish == 'true'
       shell: bash
-      run: pnpm changeset publish --tag preview --no-git-tag
+      # the prerelease transform intentionally strips devDeps, so package.json no longer
+      # matches the lockfile; skip pnpm's pre-run deps check for this one publish call.
+      run: pnpm --config.verify-deps-before-run=false changeset publish --tag preview --no-git-tag
       env:
         NPM_CONFIG_PROVENANCE: true
 


### PR DESCRIPTION
Validation-only PR for the preview publish fix.

**Fix:** `pnpm --config.verify-deps-before-run=false changeset publish` — the prerelease transform strips devDeps in place, so package.json no longer matches the lockfile; this skips pnpm's deps-check for the one publish call. Published manifest stays clean.

Carries a throwaway `@lifi/sdk-provider-tron` changeset purely to give the preview something to publish. **Targets a throwaway base branch, not main. Do not merge.**

Labeling this with `release-preview` should reproduce the previously-failing job and confirm it now gets past `ERR_PNPM_OUTDATED_LOCKFILE`.