### PR TITLE
fix(ci): skip pnpm deps-check on changeset publish

### DIFF
--- a/.github/actions/preview-publish/action.yml
+++ b/.github/actions/preview-publish/action.yml
@@ -48,7 +48,7 @@ runs:
     - name: Publish preview to npm
       if: steps.detect.outputs.publish == 'true'
       shell: bash
-      run: pnpm changeset publish --tag preview --no-git-tag
+      run: pnpm --config.verify-deps-before-run=false changeset publish --tag preview --no-git-tag
       env:
         NPM_CONFIG_PROVENANCE: true
 

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "regen": "rm -rf pnpm-lock.yaml && pnpm clean:modules && corepack use pnpm@latest",
     "changeset:version": "changeset version && pnpm install --lockfile-only && pnpm check:write",
     "changeset:prepublish": "pnpm build && pnpm -r --parallel build:prerelease",
-    "changeset:publish": "pnpm changeset:prepublish && changeset publish",
+    "changeset:publish": "pnpm changeset:prepublish && pnpm --config.verify-deps-before-run=false changeset publish",
     "check": "biome check",
     "check:write": "biome check --write",
     "check:write:unsafe": "biome check --write --unsafe",


### PR DESCRIPTION
## Problem
The preview-publish job (and the real release path) fail at `changeset publish` with:
```
[ERR_PNPM_OUTDATED_LOCKFILE] Cannot install with "frozen-lockfile" because pnpm-lock.yaml
is not up to date with packages/sdk/package.json — 8 dependencies were removed: …
```
The prerelease transform (`scripts/formatPackageJson.js`) strips `devDependencies` from each `package.json` **in place** before publishing. pnpm 11's `verify-deps-before-run` check then runs a frozen `pnpm install`, sees the manifest no longer matches the lockfile, and fails. (The old lerna flow never hit this because npm/lerna don't run pnpm's deps check.)

This breaks **both** publish paths — the `release-preview` label flow and the real `changeset:publish` release.

## Fix
Disable the deps check for the single publish invocation only — `pnpm --config.verify-deps-before-run=false changeset publish` — in both places:
- `.github/actions/preview-publish/action.yml` (preview flow)
- the `changeset:publish` script in `package.json` (release flow)

The check stays on everywhere else (dev, verify). The published manifest stays **clean** — devDeps are still stripped from the tarball.

## Validation
Ran the `release-preview` label on a test PR off this branch → published `@lifi/sdk-provider-tron@0.0.0-preview-f5cf9f8` to the `preview` dist-tag with **no lockfile error** and a **clean manifest** (no `devDependencies`, no `scripts`). OIDC trusted publishing confirmed working (no 403).

> Note: `main`'s release pipeline is *separately* red — the `verify` job flakes on a live-RPC Solana integration test (`getSolanaBalance.int.spec.ts`). Unrelated to this fix; flagged separately.