### PR TITLE
test(sdk-provider-solana): replace flaky live-RPC balance test with deterministic unit test

### DIFF
--- a/packages/sdk-provider-solana/src/actions/getSolanaBalance.int.spec.ts
+++ b/packages/sdk-provider-solana/src/actions/getSolanaBalance.int.spec.ts
@@ -67,36 +67,9 @@ describe.sequential('Solana token balance', async () => {
     await loadAndCompareTokenAmounts(walletAddress, tokens)
   })
 
-  it('should return even with invalid data', {
-    retry: retryTimes,
-    timeout,
-  }, async () => {
-    const walletAddress = defaultWalletAddress
-    const invalidToken = findDefaultToken(CoinKey.USDT, ChainId.SOL)
-    invalidToken.address = '0x2170ed0880ac9a755fd29b2688956bd959f933f8'
-    const tokens = [findDefaultToken(CoinKey.USDC, ChainId.SOL), invalidToken]
-
-    const tokenBalances = await getSolanaBalance(
-      client,
-      walletAddress,
-      tokens as Token[]
-    )
-    expect(tokenBalances.length).toBe(2)
-
-    // Post-#372 contract: a mint the wallet doesn't hold is reported as a
-    // known zero (`0n`) when both Token and Token2022 program queries
-    // succeed, and as unknown (`undefined`) when either query was rejected
-    // (rate-limit / RPC flake). Both are valid graceful-degradation
-    // outcomes for "invalid data" — assert that we got one of them and
-    // didn't crash.
-    const invalidBalance = tokenBalances.find(
-      (token) => token.address === invalidToken.address
-    )
-    expect(invalidBalance).toBeDefined()
-    expect(
-      invalidBalance!.amount === 0n || invalidBalance!.amount === undefined
-    ).toBe(true)
-  })
+  // Graceful degradation for unheld / "invalid" mints (known-zero vs unknown)
+  // is covered deterministically in getSolanaBalance.unit.spec.ts — that path
+  // makes no per-token RPC call, so it needs no live endpoint.
 
   // it(
   //   'should execute route',

--- a/packages/sdk-provider-solana/src/actions/getSolanaBalance.unit.spec.ts
+++ b/packages/sdk-provider-solana/src/actions/getSolanaBalance.unit.spec.ts
@@ -1,0 +1,117 @@
+import { ChainId, type Token } from '@lifi/sdk'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+// SPL Token program ids — mirror the constants in getSolanaBalance.ts so the
+// fake RPC can answer each program's account query independently.
+const TokenProgramId = 'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA'
+const Token2022ProgramId = 'TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb'
+
+const callSolanaRpcsWithRetry = vi.fn()
+vi.mock('../rpc/utils.js', () => ({
+  callSolanaRpcsWithRetry: (...args: unknown[]) =>
+    callSolanaRpcsWithRetry(...args),
+}))
+
+const { getSolanaBalance } = await import('./getSolanaBalance.js')
+
+// A real, valid base58 wallet address — getSolanaBalance runs it through
+// @solana/kit's address(), which validates the input.
+const WALLET = '9T655zHa6bYrTHWdy59NFqkjwoaSwfMat2yzixE1nb56'
+const HELD_MINT = 'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v'
+// A mint the wallet doesn't hold. Token addresses are only used as in-memory
+// lookup keys (never passed to address()), so the value is unconstrained —
+// this mirrors the "invalid data" case the old live integration test covered.
+const UNHELD_MINT = '0x2170ed0880ac9a755fd29b2688956bd959f933f8'
+
+const token = (address: string): Token => ({
+  chainId: ChainId.SOL,
+  address,
+  symbol: 'TKN',
+  decimals: 6,
+  name: 'Token',
+  priceUSD: '0',
+})
+
+const tokenAccount = (mint: string, amount: string) => ({
+  account: { data: { parsed: { info: { mint, tokenAmount: { amount } } } } },
+})
+
+// A fake @solana/kit RPC whose token-account queries resolve per program id.
+// An `Error` value makes that program's query reject, which getSolanaBalance
+// treats as a failed program query (rate-limit / RPC flake).
+const fakeRpc = (accountsByProgram: Record<string, object[] | Error>) => ({
+  getSlot: () => ({ send: () => Promise.resolve(123n) }),
+  getBalance: () => ({ send: () => Promise.resolve({ value: 0n }) }),
+  getTokenAccountsByOwner: (
+    _owner: unknown,
+    filter: { programId: unknown }
+  ) => ({
+    send: () => {
+      const result = accountsByProgram[String(filter.programId)] ?? []
+      return result instanceof Error
+        ? Promise.reject(result)
+        : Promise.resolve({ value: result })
+    },
+  }),
+})
+
+// Route the action's callSolanaRpcsWithRetry(client, fn) through the fake rpc,
+// so the real dispatch/aggregation logic runs against deterministic data.
+const driveWith = (rpc: object): void => {
+  callSolanaRpcsWithRetry.mockImplementation(
+    (_client: unknown, fn: (rpc: object) => Promise<unknown>) => fn(rpc)
+  )
+}
+
+describe('getSolanaBalance', () => {
+  beforeEach(() => {
+    callSolanaRpcsWithRetry.mockReset()
+  })
+
+  it('returns an empty list without touching the RPC when no tokens are requested', async () => {
+    const balances = await getSolanaBalance({} as never, WALLET, [])
+
+    expect(balances).toEqual([])
+    expect(callSolanaRpcsWithRetry).not.toHaveBeenCalled()
+  })
+
+  it('reports an unheld mint as a known zero when both program queries succeed', async () => {
+    driveWith(
+      fakeRpc({
+        [TokenProgramId]: [tokenAccount(HELD_MINT, '500')],
+        [Token2022ProgramId]: [],
+      })
+    )
+
+    const balances = await getSolanaBalance({} as never, WALLET, [
+      token(HELD_MINT),
+      token(UNHELD_MINT),
+    ])
+
+    const held = balances.find((balance) => balance.address === HELD_MINT)
+    const unheld = balances.find((balance) => balance.address === UNHELD_MINT)
+    expect(held?.amount).toBe(500n)
+    expect(held?.blockNumber).toBe(123n)
+    // Both Token and Token2022 queries succeeded → a definite zero.
+    expect(unheld?.amount).toBe(0n)
+    expect(unheld?.blockNumber).toBe(123n)
+  })
+
+  it('reports an unheld mint as unknown (undefined) when a program query fails', async () => {
+    driveWith(
+      fakeRpc({
+        [TokenProgramId]: [],
+        [Token2022ProgramId]: new Error('RPC rate-limited'),
+      })
+    )
+
+    const [unheld] = await getSolanaBalance({} as never, WALLET, [
+      token(UNHELD_MINT),
+    ])
+
+    // A program query was rejected, so a missing mint can't be reported as a
+    // confident zero — it stays undefined (graceful degradation, no throw).
+    expect(unheld.amount).toBeUndefined()
+    expect(unheld.blockNumber).toBe(123n)
+  })
+})


### PR DESCRIPTION
## Problem

The `Verify` job (and PR `Tests`) has been **red-gating `main` and the release pipeline**. The failure is a timeout in a **live-RPC integration test**:

```
packages/sdk-provider-solana/src/actions/getSolanaBalance.int.spec.ts
  > Solana token balance > should return even with invalid data
  Error: Test timed out in 10000ms.  (retry ×2 → 3 attempts, all timed out)
```

It's a **flake, not a regression**:
- PRs touching **zero Solana code** (e.g. "refine /changeset skill", "fix preview deps-check") also fail this gate → code-independent.
- The same branch flips green↔red across runs.
- The failing test's RPC calls are **byte-identical** to the passing "should work for stables on SOL" test — the per-token address is only an in-memory lookup key in `getSolanaBalance`, never sent to the RPC. Being the 3rd sequential test against the public RPC, it's the one that hits throttling.

So the test's only *unique* value was the in-memory graceful-degradation assertion, which is environment-independent and doesn't need a live endpoint.

## Fix

- **Move** that assertion into a new `getSolanaBalance.unit.spec.ts` with a mocked RPC (following the existing `vi.mock('../rpc/utils.js', …)` convention used by the WaitForTransaction task specs).
- Cover **both** documented outcomes deterministically (stronger than the int test's "either is acceptable"):
  - **known-zero** (`0n`) when both Token and Token2022 program queries succeed, and
  - **unknown** (`undefined`) when a program query fails (rate-limit / RPC flake).
- Plus a no-token early-return case asserting the RPC isn't touched.
- **Remove** the flaky `it(…)` from the integration spec, leaving a comment pointing to the unit coverage.

Runs in ~4ms, no network dependency. Full solana unit suite: **52 passed** (49 + 3 new).

## Scope note

This is the targeted "mock just this test" fix. The other two cases in `getSolanaBalance.int.spec.ts` (`empty lists`, `stables on SOL`) still run live in CI and could in principle flake, but removing the 3rd sequential test cuts the RPC pressure that was tipping the suite over the 10s timeout. A broader follow-up (move all `*.int.spec.ts` out of the blocking gate into a nightly/`workflow_dispatch` workflow) remains an option if live-RPC flakiness recurs.

Test-only change → no changeset (per repo rules).