### PR TITLE
chore(changeset): set updateInternalDependencies to patch

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -9,7 +9,7 @@
   "fixed": [],
   "linked": [],
   "baseBranch": "main",
-  "updateInternalDependencies": "minor",
+  "updateInternalDependencies": "patch",
   "ignore": [],
   "snapshot": { "prereleaseTemplate": "{tag}" }
 }

--- a/.claude/skills/changeset/SKILL.md
+++ b/.claude/skills/changeset/SKILL.md
@@ -57,7 +57,7 @@ real gate). Your job here is to write a correct changeset for the work in progre
 ## Key rules (full detail in `references/`)
 
 - **Only declare packages you intentionally changed.** Internal dependents re-release
-  automatically (`updateInternalDependencies: minor`); authoring changesets for them
+  automatically (`updateInternalDependencies: patch`); authoring changesets for them
   double-counts and produces noisy changelogs.
 - **Skip** docs-only, chore-only, test-only, and private-package-only changes. For a
   deliberately release-less change, `pnpm changeset --empty`.

--- a/.claude/skills/changeset/references/bump-rules.md
+++ b/.claude/skills/changeset/references/bump-rules.md
@@ -29,7 +29,7 @@ There are no private/ignored workspace packages (`.changeset/config.json` `ignor
 ```
 
 Providers depend on `@lifi/sdk` via `workspace:*` regular `dependencies`. With
-`updateInternalDependencies: minor`, bumping `@lifi/sdk` **re-releases every provider
+`updateInternalDependencies: patch`, bumping `@lifi/sdk` **re-releases every provider
 automatically** with an updated range. So:
 
 - Changed `@lifi/sdk` source only → declare a changeset for **just** `@lifi/sdk`; the five

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,8 +45,9 @@ standard-version are gone.
   docs/chore PRs simply don't need one. The Version PR is the real publish gate.)
 - Only declare changesets for packages you *intentionally* changed. Do **not** author
   cascade-only changesets for dependents — Changesets bumps providers automatically from the
-  dependency graph when `@lifi/sdk` changes. (`updateInternalDependencies: "minor"` only tunes
-  the threshold at which a provider's internal `@lifi/sdk` *range* is rewritten — minor/major, not patch.)
+  dependency graph when `@lifi/sdk` changes. (`updateInternalDependencies: "patch"` — the
+  default — re-releases every provider on *any* `@lifi/sdk` bump, including a patch, so their
+  `workspace:*` pins stay current.)
 
 ### PRE-MODE (beta) — do not exit until cutting stable 4.0.0
 - The repo is in Changesets **pre-mode** (`.changeset/pre.json`, `tag: beta`). Latest on


### PR DESCRIPTION
Sets `updateInternalDependencies` back to the Changesets default (`patch`) so **any** bump to a workspace package — including a patch — re-releases its internal dependents, keeping their pinned (`workspace:*`/`workspace:^`) versions current instead of lagging until the next minor.

Updates the CLAUDE.md / changeset-skill references to match. No code changes.