### PR TITLE
Fix token balances chain id validation

### DIFF
--- a/packages/sdk/src/actions/getTokenBalancesByChain.ts
+++ b/packages/sdk/src/actions/getTokenBalancesByChain.ts
@@ -36,6 +36,12 @@ export async function getTokenBalancesByChain(
   if (invalidTokens.length) {
     throw new ValidationError('Invalid tokens passed.')
   }
+  const chainIds = Object.keys(tokensByChain).map((chainIdStr) => {
+    if (!/^\d+$/u.test(chainIdStr)) {
+      throw new ValidationError('Invalid chainId passed.')
+    }
+    return Number.parseInt(chainIdStr, 10)
+  })
 
   const provider = client.providers.find((provider) =>
     provider.isAddress(walletAddress)
@@ -48,8 +54,7 @@ export async function getTokenBalancesByChain(
     [chainId: number]: TokenAmount[] | TokenAmountExtended[]
   } = {}
   const tokenAmountsSettled = await Promise.allSettled(
-    Object.keys(tokensByChain).map(async (chainIdStr) => {
-      const chainId = Number.parseInt(chainIdStr, 10)
+    chainIds.map(async (chainId) => {
       const chain = await client.getChainById(chainId)
       if (provider.type === chain.chainType) {
         const tokenAmounts = await provider.getBalance(

--- a/packages/sdk/src/actions/getTokenBalancesByChain.unit.spec.ts
+++ b/packages/sdk/src/actions/getTokenBalancesByChain.unit.spec.ts
@@ -38,6 +38,14 @@ describe('getTokenBalancesByChain', () => {
       ).rejects.toThrow('Invalid tokens passed.')
     })
 
+    it('should throw Error because of an invalid chain id', async () => {
+      await expect(
+        getTokenBalancesByChain(client, SOME_WALLET_ADDRESS, {
+          ['1abc' as unknown as ChainId]: [SOME_TOKEN],
+        })
+      ).rejects.toThrow('Invalid chainId passed.')
+    })
+
     it('should return empty token list as it is', async () => {
       mockedGetTokenBalancesForChains.mockReturnValue(Promise.resolve([]))
 


### PR DESCRIPTION
Fixes token balance chain id handling so malformed keys are rejected instead of being partially parsed. Adds regression coverage for invalid chain ids.