### PR TITLE
chore: exclude first-party scopes from release-age floor + bump @bigmi/core

### DIFF
--- a/.changeset/bump-bigmi-core.md
+++ b/.changeset/bump-bigmi-core.md
@@ -1,0 +1,5 @@
+---
+"@lifi/sdk-provider-bitcoin": patch
+---
+
+Bump @bigmi/core to 0.8.1.

--- a/.claude/skills/bump-packages/SKILL.md
+++ b/.claude/skills/bump-packages/SKILL.md
@@ -34,7 +34,9 @@ external dependencies current is routine maintenance, but three things make a bl
    pnpm, holds a too-fresh release back to the newest aged version on its own — and preserves
    each dependency's existing prefix (`^`, `~`, or a deliberate exact pin) — verified for all
    three. So you don't hand-write versions; you let pnpm resolve, and report what it held
-   back.
+   back. Packages matched by **`minimumReleaseAgeExclude`** in `pnpm-workspace.yaml` (our
+   trusted first-party scopes — `@bigmi/*`, `@lifi/*`) bypass the floor; the analysis script
+   reads that list and won't predict holding them back, matching pnpm.
 
 The deterministic parts — discovering outdated deps, predicting the aged target pnpm will
 land on, classifying each by SemVer risk, and working out which publishable packages need a

--- a/.claude/skills/bump-packages/scripts/analyze-outdated.mjs
+++ b/.claude/skills/bump-packages/scripts/analyze-outdated.mjs
@@ -82,8 +82,11 @@ function getOutdatedJson(root) {
 
 function readWorkspaceYaml(root) {
   const p = confine(root, 'pnpm-workspace.yaml')
+  if (!p) {
+    return ''
+  }
   try {
-    return p ? readFileSync(p, 'utf8') : ''
+    return readFileSync(p, 'utf8')
   } catch {
     return ''
   }

--- a/.claude/skills/bump-packages/scripts/analyze-outdated.mjs
+++ b/.claude/skills/bump-packages/scripts/analyze-outdated.mjs
@@ -75,17 +75,82 @@ function getOutdatedJson(root) {
   return start === -1 ? {} : JSON.parse(out.slice(start))
 }
 
-// Best-effort read of an explicit minimumReleaseAge (minutes) from pnpm-workspace.yaml.
-function configuredMinAgeHours(root) {
+// --- pnpm-workspace.yaml: age floor + exclude list -------------------------
+// Mirror pnpm's `minimumReleaseAge` / `minimumReleaseAgeExclude` so the plan predicts
+// exactly what pnpm will install — excluded packages (trusted first-party, or a knowingly
+// fast-tracked release) bypass the floor and must not be reported as held back.
+
+function readWorkspaceYaml(root) {
   const p = confine(root, 'pnpm-workspace.yaml')
-  let yaml = ''
   try {
-    yaml = p ? readFileSync(p, 'utf8') : ''
+    return p ? readFileSync(p, 'utf8') : ''
   } catch {
-    yaml = ''
+    return ''
   }
+}
+
+function minAgeHoursFromYaml(yaml) {
   const m = yaml.match(/^\s*minimumReleaseAge\s*:\s*(\d+)/m)
   return m ? Number(m[1]) / 60 : null
+}
+
+// Pull the `minimumReleaseAgeExclude:` list entries (quoted or bare) out of the yaml.
+function excludesFromYaml(yaml) {
+  const block = yaml.match(
+    /^minimumReleaseAgeExclude:\s*\n((?:[ \t]+-.*\n?)+)/m
+  )
+  if (!block) {
+    return []
+  }
+  return [...block[1].matchAll(/^[ \t]+-\s*['"]?([^'"\n]+?)['"]?\s*$/gm)].map(
+    (x) => x[1].trim()
+  )
+}
+
+// '*' is the only wildcard; everything else is literal.
+function globToRegExp(glob) {
+  const body = glob
+    .split('*')
+    .map((s) => s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'))
+    .join('.*')
+  return new RegExp(`^${body}$`)
+}
+
+// Build matchers from exclude entries: a name/glob, an exact `name@version`, or a `||`
+// disjunction of versions for one name (e.g. `webpack@4.47.0 || 5.102.1`).
+function parseExcludes(entries) {
+  const matchers = []
+  for (const raw of entries) {
+    let lastName = null
+    for (const piece of String(raw)
+      .split('||')
+      .map((s) => s.trim())
+      .filter(Boolean)) {
+      const at = piece.lastIndexOf('@')
+      let name
+      let version
+      if (at > 0) {
+        name = piece.slice(0, at)
+        version = piece.slice(at + 1)
+      } else if (lastName && /^[0-9]/.test(piece)) {
+        name = lastName // bare version continuing the previous name
+        version = piece
+      } else {
+        name = piece // a name or glob — all versions
+        version = null
+      }
+      lastName = name
+      matchers.push({ re: globToRegExp(name), version })
+    }
+  }
+  return matchers
+}
+
+// Does `name@version` bypass the age floor per the exclude matchers?
+function isExcluded(matchers, name, version) {
+  return matchers.some(
+    (m) => m.re.test(name) && (m.version == null || m.version === version)
+  )
 }
 
 // Fetch publish timestamps for every candidate, concurrently. `npm view` (not a raw
@@ -146,9 +211,9 @@ function cmp(a, b) {
   return 0
 }
 
-// Newest version strictly above `current` that is already older than the age floor.
-// Skips prereleases unless `current` is itself a prerelease. Returns version string | null.
-function pickAgedTarget(timeMap, currentRaw, minAgeMs, nowMs) {
+// Newest version strictly above `current` that has aged past the floor — or is exempt via
+// minimumReleaseAgeExclude. Skips prereleases unless `current` is itself a prerelease.
+function pickAgedTarget(timeMap, currentRaw, minAgeMs, nowMs, isExempt) {
   if (!timeMap) {
     return null
   }
@@ -163,9 +228,11 @@ function pickAgedTarget(timeMap, currentRaw, minAgeMs, nowMs) {
     if ((p.pre && !cur.pre) || cmp(p, cur) <= 0) {
       continue
     }
+    // Eligible once it has aged past the floor, or if it's exempt from the floor entirely.
     const published = Date.parse(iso)
-    if (!Number.isFinite(published) || nowMs - published < minAgeMs) {
-      continue // missing date, or too fresh — held back by the floor
+    const aged = Number.isFinite(published) && nowMs - published >= minAgeMs
+    if (!(aged || isExempt(ver))) {
+      continue
     }
     if (!best || cmp(p, best) > 0) {
       best = p
@@ -245,10 +312,11 @@ async function main() {
   const args = getArgs()
   const outdated = getOutdatedJson(args.root)
   const workspaces = listWorkspacePackages(args.root)
+  const wsYaml = readWorkspaceYaml(args.root)
+  const excludeMatchers = parseExcludes(excludesFromYaml(wsYaml))
 
   const minAgeHours =
-    Math.max(args.minAgeHours || 24, configuredMinAgeHours(args.root) || 0) ||
-    24
+    Math.max(args.minAgeHours || 24, minAgeHoursFromYaml(wsYaml) || 0) || 24
   const minAgeMs = minAgeHours * 3600 * 1000
   const nowMs = Date.now()
 
@@ -273,7 +341,13 @@ async function main() {
       deprecated.push(name)
     }
 
-    const target = pickAgedTarget(times.get(name), current, minAgeMs, nowMs)
+    const target = pickAgedTarget(
+      times.get(name),
+      current,
+      minAgeMs,
+      nowMs,
+      (ver) => isExcluded(excludeMatchers, name, ver)
+    )
     if (!target) {
       // Updates exist but the newest is younger than the floor — report, don't bump.
       const latestIso = times.get(name)?.[registryLatest]

--- a/packages/sdk-provider-bitcoin/package.json
+++ b/packages/sdk-provider-bitcoin/package.json
@@ -43,7 +43,7 @@
     "watch": "tsdown --watch"
   },
   "dependencies": {
-    "@bigmi/core": "^0.8.0",
+    "@bigmi/core": "^0.8.1",
     "@bitcoinerlab/secp256k1": "^1.2.0",
     "@lifi/sdk": "workspace:*",
     "bech32": "^2.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -85,8 +85,8 @@ importers:
   packages/sdk-provider-bitcoin:
     dependencies:
       '@bigmi/core':
-        specifier: ^0.8.0
-        version: 0.8.0(bs58@6.0.0)(typescript@6.0.3)
+        specifier: ^0.8.1
+        version: 0.8.1(bs58@6.0.0)(typescript@6.0.3)
       '@bitcoinerlab/secp256k1':
         specifier: ^1.2.0
         version: 1.2.0
@@ -319,8 +319,8 @@ packages:
     resolution: {integrity: sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==}
     engines: {node: '>=18'}
 
-  '@bigmi/core@0.8.0':
-    resolution: {integrity: sha512-eTFRfLIonUwcgYeHdgfiRKkO9Nb49ZUT7EyS+5Q76HsKGsZyXaemrJvpL8gKLSuVIQAegS7CVPaEC6gZxn1RyA==}
+  '@bigmi/core@0.8.1':
+    resolution: {integrity: sha512-PX0x2iid3p4cWugP4qI4SPqsGuiogQGcwOLDnsMRkifr4z9rKFZl7CE4I9ynUSVDsqkw0PL/0iPIpN4EqhRqNQ==}
     peerDependencies:
       bs58: ^6.0.0
 
@@ -3511,7 +3511,7 @@ snapshots:
 
   '@bcoe/v8-coverage@1.0.2': {}
 
-  '@bigmi/core@0.8.0(bs58@6.0.0)(typescript@6.0.3)':
+  '@bigmi/core@0.8.1(bs58@6.0.0)(typescript@6.0.3)':
     dependencies:
       '@noble/hashes': 1.8.0
       bech32: 2.0.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -3,5 +3,11 @@ packages:
 allowBuilds:
   msw: true
   nx: true
+# First-party scopes we publish and consume across repos: trusted by our own pipeline
+# (CI-only publish, npm provenance, 2FA), so they bypass the 24h minimumReleaseAge floor
+# that protects against third-party supply-chain compromise. Set once; no per-release churn.
+minimumReleaseAgeExclude:
+  - '@bigmi/*'
+  - '@lifi/*'
 overrides:
   axios: ^1.16.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -3,9 +3,6 @@ packages:
 allowBuilds:
   msw: true
   nx: true
-# First-party scopes we publish and consume across repos: trusted by our own pipeline
-# (CI-only publish, npm provenance, 2FA), so they bypass the 24h minimumReleaseAge floor
-# that protects against third-party supply-chain compromise. Set once; no per-release churn.
 minimumReleaseAgeExclude:
   - '@bigmi/*'
   - '@lifi/*'


### PR DESCRIPTION
## What

Three related changes around pnpm's 24h `minimumReleaseAge` floor and a first-party bump.

### 1. Trust our own scopes — `minimumReleaseAgeExclude`
The 24h floor is a defense against **third-party** supply-chain compromise. Our own packages (`@bigmi/*`, `@lifi/*`) are published by our own pipeline (CI-only, npm provenance, 2FA), so the cooldown is friction without payoff — it blocks the "release `@bigmi/core`, consume it in `sdk` immediately" cross-repo flow. `pnpm-workspace.yaml` now exempts those scopes:

```yaml
minimumReleaseAgeExclude:
  - '@bigmi/*'
  - '@lifi/*'
```

Set once — no per-release churn, no stale version-pins to prune. The floor still covers the entire third-party surface where the real risk lives.

### 2. `/bump-packages` skill now honors the exclude
`analyze-outdated.mjs` predicts what pnpm will install under the floor. It now reads `minimumReleaseAgeExclude` (globs, `name@version`, and `||` disjunctions) and **doesn't predict holding excluded packages back** — keeping the plan in sync with pnpm. Unit-tested across all entry forms.

### 3. Bump `@bigmi/core` 0.8.0 → 0.8.1
Runtime dependency of `@lifi/sdk-provider-bitcoin` → `patch` changeset included.

## Validation
`build`, `check`, `check:types`, `check:circular-deps`, `knip`, `test:unit` all pass. `pnpm changeset status` → `@lifi/sdk-provider-bitcoin` patch.