### PR TITLE
chore(release): exit beta pre-mode — ⚠️ merging cuts stable 4.0.0 to npm latest

### DIFF
--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -1,5 +1,5 @@
 {
-  "mode": "pre",
+  "mode": "exit",
   "tag": "beta",
   "initialVersions": {
     "@lifi/sdk": "4.0.0-beta.11",


### PR DESCRIPTION
**Exits Changesets pre/beta mode for the v4 line.** This PR only flips `.changeset/pre.json` `mode: pre → exit` — **no versioning happens here** (one-line diff).

### What merging this sets in motion
1. The next push to `main` runs the changesets job, now in *exit* mode — it versions the **stable `4.0.0`** (consuming the accumulated beta changesets, dropping the `-beta.N` suffix), removes `pre.json`, and opens the **"chore: version packages"** PR at `4.0.0`.
2. Merging *that* version PR publishes **`4.0.0` to the `latest` dist-tag** — moving npm `latest` from `3.16.3` → `4.0.0`.

> ⚠️ **Do not merge until v4 is ready to be the stable `latest` release.** Opened as a **draft** for that reason — mark ready + merge when you're set to go stable.

### Sequence
Cut **sdk** stable first; then bump widget's `@lifi/sdk` dep (`^4.0.0-beta.11 → ^4.0.0`) and exit widget's beta.