### PR TITLE
feat: migrate Sui provider off deprecated JSON-RPC to gRPC core API (EMB-459)

### DIFF
--- a/.changeset/sui-grpc-migration.md
+++ b/.changeset/sui-grpc-migration.md
@@ -1,0 +1,5 @@
+---
+'@lifi/sdk-provider-sui': minor
+---
+
+Migrate the Sui integration off the deprecated JSON-RPC client (`SuiJsonRpcClient`) to the gRPC Core API (`SuiGrpcClient` / `client.core.*`) ahead of Sui's JSON-RPC sunset. Balance fetching (`listBalances`, now paginated), latest-checkpoint lookup (`ledgerService.getServiceInfo`), transaction confirmation (`core.waitForTransaction`), and SuiNS resolution (`nameService.lookupName`) now use gRPC. No public API changes.

--- a/packages/sdk-provider-sui/src/actions/getSuiBalance.ts
+++ b/packages/sdk-provider-sui/src/actions/getSuiBalance.ts
@@ -4,6 +4,7 @@ import {
   type TokenAmount,
   withDedupe,
 } from '@lifi/sdk'
+import type { SuiClientTypes } from '@mysten/sui/client'
 import { callSuiWithRetry } from '../client/suiClient.js'
 import { SuiTokenLongAddress, SuiTokenShortAddress } from '../types.js'
 
@@ -35,30 +36,39 @@ const getSuiBalanceDefault = async (
   const [coins, checkpoint] = await Promise.allSettled([
     withDedupe(
       () =>
-        callSuiWithRetry(client, (client) =>
-          client.getAllBalances({
-            owner: walletAddress,
-          })
-        ),
-      { id: `${getSuiBalanceDefault.name}.getAllBalances` }
+        callSuiWithRetry(client, async (suiClient) => {
+          // listBalances is paginated; page through to collect every coin type.
+          const balances: SuiClientTypes.Balance[] = []
+          let cursor: string | null | undefined
+          do {
+            const page = await suiClient.core.listBalances({
+              owner: walletAddress,
+              cursor,
+            })
+            balances.push(...page.balances)
+            cursor = page.hasNextPage ? page.cursor : null
+          } while (cursor)
+          return balances
+        }),
+      { id: `${getSuiBalanceDefault.name}.listBalances` }
     ),
     withDedupe(
       () =>
-        callSuiWithRetry(client, (client) =>
-          client.getLatestCheckpointSequenceNumber()
-        ),
-      { id: `${getSuiBalanceDefault.name}.getLatestCheckpointSequenceNumber` }
+        callSuiWithRetry(client, async (suiClient) => {
+          const { response } = await suiClient.ledgerService.getServiceInfo({})
+          return response.checkpointHeight ?? 0n
+        }),
+      { id: `${getSuiBalanceDefault.name}.getServiceInfo` }
     ),
   ])
 
   const coinsOk = coins.status === 'fulfilled'
   const coinsResult = coinsOk ? coins.value : []
-  const blockNumber =
-    checkpoint.status === 'fulfilled' ? BigInt(checkpoint.value) : 0n
+  const blockNumber = checkpoint.status === 'fulfilled' ? checkpoint.value : 0n
 
   const walletTokenAmounts = coinsResult.reduce(
     (tokenAmounts, coin) => {
-      const amount = BigInt(coin.totalBalance)
+      const amount = BigInt(coin.balance)
       if (amount > 0n) {
         tokenAmounts[coin.coinType] = amount
       }
@@ -67,13 +77,18 @@ const getSuiBalanceDefault = async (
     {} as Record<string, bigint>
   )
 
+  // The native SUI coin type can be returned in short (`0x2::sui::SUI`) or
+  // fully-normalized (`0x0000…0002::sui::SUI`) form depending on the RPC.
+  // Map both so token lists using either format resolve.
   const suiTokenBalance = coinsResult.find(
-    (coin) => coin.coinType === SuiTokenShortAddress
+    (coin) =>
+      coin.coinType === SuiTokenShortAddress ||
+      coin.coinType === SuiTokenLongAddress
   )
-  if (suiTokenBalance?.totalBalance) {
-    walletTokenAmounts[SuiTokenLongAddress] = BigInt(
-      suiTokenBalance.totalBalance
-    )
+  if (suiTokenBalance?.balance) {
+    const suiAmount = BigInt(suiTokenBalance.balance)
+    walletTokenAmounts[SuiTokenShortAddress] = suiAmount
+    walletTokenAmounts[SuiTokenLongAddress] = suiAmount
   }
 
   const tokenAmounts: TokenAmount[] = tokens.map((token) => {

--- a/packages/sdk-provider-sui/src/actions/getSuiNSAddress.ts
+++ b/packages/sdk-provider-sui/src/actions/getSuiNSAddress.ts
@@ -1,41 +1,19 @@
 import type { SuiClientTypes } from '@mysten/sui/client'
-import { SuiJsonRpcClient } from '@mysten/sui/jsonRpc'
-
-const SNS_REGISTRY_ID =
-  '0x6e0ddefc0ad3ed64f53f5f91b7023077b2f7c131d7e6d5e0d1a0e4e6f1a2c3b4'
+import { SuiGrpcClient } from '@mysten/sui/grpc'
 
 export async function getSuiNSAddress(
   name: string,
   rpcUrl?: string,
   network?: SuiClientTypes.Network
 ): Promise<string | undefined> {
-  const client = new SuiJsonRpcClient({
-    url: rpcUrl || 'https://fullnode.mainnet.sui.io:443',
+  const client = new SuiGrpcClient({
     network: network || 'mainnet',
+    baseUrl: rpcUrl || 'https://fullnode.mainnet.sui.io:443',
   })
 
   try {
-    const result = await client.getObject({
-      id: SNS_REGISTRY_ID,
-      options: {
-        showContent: true,
-      },
-    })
-
-    if (!result.data?.content) {
-      return
-    }
-
-    const registry = result.data.content as any
-    const nameRecord = registry.fields.records.find(
-      (record: any) => record.fields.name === name
-    )
-
-    if (!nameRecord) {
-      return
-    }
-
-    return nameRecord.fields.address
+    const { response } = await client.nameService.lookupName({ name })
+    return response.record?.targetAddress
   } catch (error) {
     console.error('Error resolving SuiNS address:', error)
     return

--- a/packages/sdk-provider-sui/src/client/suiClient.ts
+++ b/packages/sdk-provider-sui/src/client/suiClient.ts
@@ -1,7 +1,7 @@
 import { ChainId, type SDKClient } from '@lifi/sdk'
-import { SuiJsonRpcClient } from '@mysten/sui/jsonRpc'
+import { SuiGrpcClient } from '@mysten/sui/grpc'
 
-const clients = new Map<string, SuiJsonRpcClient>()
+const clients = new Map<string, SuiGrpcClient>()
 
 /**
  * Initializes the Sui clients if they haven't been initialized yet.
@@ -11,21 +11,21 @@ const ensureClients = async (client: SDKClient): Promise<void> => {
   const rpcUrls = await client.getRpcUrlsByChainId(ChainId.SUI)
   for (const rpcUrl of rpcUrls) {
     if (!clients.get(rpcUrl)) {
-      const client = new SuiJsonRpcClient({ url: rpcUrl, network: 'mainnet' })
+      const client = new SuiGrpcClient({ network: 'mainnet', baseUrl: rpcUrl })
       clients.set(rpcUrl, client)
     }
   }
 }
 
 /**
- * Calls a function on the SuiJsonRpcClient instances with retry logic.
+ * Calls a function on the SuiGrpcClient instances with retry logic.
  * @param client - The SDK client
- * @param fn - The function to call, which receives a SuiJsonRpcClient instance.
+ * @param fn - The function to call, which receives a SuiGrpcClient instance.
  * @returns - The result of the function call.
  */
 export async function callSuiWithRetry<R>(
   client: SDKClient,
-  fn: (client: SuiJsonRpcClient) => Promise<R>
+  fn: (client: SuiGrpcClient) => Promise<R>
 ): Promise<R> {
   // Ensure clients are initialized
   await ensureClients(client)

--- a/packages/sdk-provider-sui/src/core/tasks/SuiWaitForTransactionTask.ts
+++ b/packages/sdk-provider-sui/src/core/tasks/SuiWaitForTransactionTask.ts
@@ -37,25 +37,23 @@ export class SuiWaitForTransactionTask extends BaseStepExecutionTask {
     }
 
     const result = await callSuiWithRetry(client, (client) =>
-      client.waitForTransaction({
+      client.core.waitForTransaction({
         digest: signedTransaction.digest,
-        options: {
-          showEffects: true,
-        },
       })
     )
 
-    if (result.effects?.status.status !== 'success') {
+    const transaction = result.Transaction ?? result.FailedTransaction
+    if (!transaction?.status.success) {
       throw new TransactionError(
         LiFiErrorCode.TransactionFailed,
-        `Transaction failed: ${result.effects?.status.error}`
+        `Transaction failed: ${transaction?.status.error?.message ?? `Unexpected transaction result: ${result.$kind}`}`
       )
     }
 
     // Transaction has been confirmed and we can update the action
     statusManager.updateAction(step, action.type, 'PENDING', {
-      txHash: result.digest,
-      txLink: `${fromChain.metamask.blockExplorerUrls[0]}txblock/${result.digest}`,
+      txHash: transaction.digest,
+      txLink: `${fromChain.metamask.blockExplorerUrls[0]}txblock/${transaction.digest}`,
     })
 
     if (isBridgeExecution) {


### PR DESCRIPTION
## Which Linear task is linked to this PR?

[EMB-459](https://linear.app/lifi-linear/issue/EMB-459)

## Why was it implemented this way?

Sui is sunsetting the JSON-RPC API in favor of gRPC/GraphQL (deadline ~July 2026 — see the [Sui 2.0 JSON-RPC migration guide](https://sdk.mystenlabs.com/sui/migrations/sui-2.0/json-rpc-migration)). The execution path already used the new unified Core API (`suiClient.core.signAndExecuteTransaction`); this finishes the migration by moving the remaining **read path** off the deprecated `SuiJsonRpcClient` (`@mysten/sui/jsonRpc`) onto `SuiGrpcClient` (`@mysten/sui/grpc`).

Changes (`packages/sdk-provider-sui`):

- **`client/suiClient.ts`** — the retry pool now builds `SuiGrpcClient` instances (`{ network, baseUrl }`) instead of `SuiJsonRpcClient`. The multi-RPC retry behaviour is unchanged.
- **`actions/getSuiBalance.ts`** — `getAllBalances` → `core.listBalances`, which is **paginated**, so we now page through `cursor`/`hasNextPage` to collect every coin type (the old call returned everything at once). Per-coin total reads from `Balance.balance`. `getLatestCheckpointSequenceNumber` → `ledgerService.getServiceInfo().checkpointHeight`. The native SUI coin is mapped under both its short (`0x2::sui::SUI`) and normalized long form to stay robust to the coin-type format the gRPC endpoint returns.
- **`core/tasks/SuiWaitForTransactionTask.ts`** — `waitForTransaction` → `core.waitForTransaction`; the result is the `{ $kind, Transaction, FailedTransaction }` union, and success is now `transaction.status.success` (boolean) with the error on `status.error.message`.
- **`actions/getSuiNSAddress.ts`** — replaced the hand-rolled registry-object traversal with the dedicated `nameService.lookupName` gRPC call (returns `record.targetAddress`).

No public API changes — `SuiProvider`'s surface is identical. Kept the existing multi-URL pool (smaller diff, preserves resilience) rather than reusing the injected client, since the checkpoint lookup needs the gRPC-specific `ledgerService`. No backend RPC change is required: the configured Sui fullnode already serves gRPC on the same host/port.

### Validation

- `pnpm check:types`, `pnpm check` (biome), `pnpm build`, `pnpm test:unit` — all green.
- **Live**: `getSuiBalance.int.spec.ts` passes against mainnet (balances, pagination, `checkpointHeight`, SUI/USDC coin-type mapping).
- **Live**: `nameService.lookupName` smoke-tested — resolves a registered `.sui` name and returns `undefined` gracefully for unregistered/expired names.

## Visual showcase (Screenshots or Videos)

N/A — internal transport migration.

## Checklist before requesting a review
- [x] I have performed a self-review and testing of my code.
- [x] This pull request is focused and addresses a single problem.
- [ ] If this PR modifies the SDK API or adds new features that require documentation, I have updated the documentation in the [public-docs](https://github.com/lifinance/public-docs) repository. _(No public API change.)_
