### PR TITLE
refactor: use getJsonRpcFullnodeUrl helper for SuiNS default RPC URL

### DIFF
--- a/.changeset/sui-rpc-url-helper.md
+++ b/.changeset/sui-rpc-url-helper.md
@@ -1,0 +1,5 @@
+---
+'@lifi/sdk-provider-sui': patch
+---
+
+Use the `getJsonRpcFullnodeUrl` helper for the default Sui fullnode URL in SuiNS resolution instead of a hardcoded string. No behavior change — the helper returns the same mainnet endpoint.

--- a/packages/sdk-provider-sui/src/actions/getSuiNSAddress.ts
+++ b/packages/sdk-provider-sui/src/actions/getSuiNSAddress.ts
@@ -1,5 +1,6 @@
 import type { SuiClientTypes } from '@mysten/sui/client'
 import { SuiGrpcClient } from '@mysten/sui/grpc'
+import { getJsonRpcFullnodeUrl } from '@mysten/sui/jsonRpc'
 
 export async function getSuiNSAddress(
   name: string,
@@ -8,7 +9,7 @@ export async function getSuiNSAddress(
 ): Promise<string | undefined> {
   const client = new SuiGrpcClient({
     network: network || 'mainnet',
-    baseUrl: rpcUrl || 'https://fullnode.mainnet.sui.io:443',
+    baseUrl: rpcUrl || getJsonRpcFullnodeUrl('mainnet'),
   })
 
   try {


### PR DESCRIPTION
## Which Linear task is linked to this PR?

Follow-up to [EMB-459](https://linear.app/lifi-linear/issue/EMB-459) (Sui JSON-RPC → gRPC migration).

## Why was it implemented this way?

The Sui gRPC migration ([#404](https://github.com/lifinance/sdk/pull/404)) left a hardcoded fullnode URL (`'https://fullnode.mainnet.sui.io:443'`) as the default in `getSuiNSAddress`. This swaps it for the SDK's own `getJsonRpcFullnodeUrl('mainnet')` helper (`@mysten/sui/jsonRpc`).

- `getJsonRpcFullnodeUrl` is just a **URL-string helper** — it returns the same mainnet endpoint, so there is **no behavior change**. It is not the deprecated `SuiJsonRpcClient`, and it tree-shakes cleanly.
- The same fullnode host serves both JSON-RPC and gRPC on `:443`, so it remains the correct `baseUrl` for `SuiGrpcClient`.
- Used the `'mainnet'` literal (not the `network` param) because `getJsonRpcFullnodeUrl` only accepts the four standard networks and throws otherwise, whereas `SuiClientTypes.Network` permits custom strings — this matches the previous always-mainnet default exactly.

## Visual showcase (Screenshots or Videos)

N/A — one-line default-URL refactor.

## Checklist before requesting a review
- [x] I have performed a self-review and testing of my code.
- [x] This pull request is focused and addresses a single problem.
- [ ] If this PR modifies the SDK API or adds new features that require documentation, I have updated the documentation in the [public-docs](https://github.com/lifinance/public-docs) repository. _(No API change.)_

### Validation
- `pnpm check:types`, `pnpm check` (biome), `pnpm build` — all green. No behavior change (helper returns the identical URL string).
