### PR TITLE
feat(sdk): add private param for getRoutes

### DIFF
--- a/.changeset/get-routes-private-option.md
+++ b/.changeset/get-routes-private-option.md
@@ -1,0 +1,5 @@
+---
+'@lifi/sdk': minor
+---
+
+Add an optional `private` flag to `getRoutes` route options, allowing callers to request private routes.

--- a/packages/sdk/src/actions/getRoutes.ts
+++ b/packages/sdk/src/actions/getRoutes.ts
@@ -1,6 +1,7 @@
-import type { RequestOptions, RoutesRequest, RoutesResponse } from '@lifi/types'
+import type { RequestOptions, RoutesResponse } from '@lifi/types'
 import { ValidationError } from '../errors/errors.js'
 import { SDKError } from '../errors/SDKError.js'
+import type { RoutesRequest } from '../types/actions.js'
 import type { SDKClient } from '../types/core.js'
 import { isRoutesRequest } from '../utils/isRoutesRequest.js'
 import { request } from '../utils/request.js'

--- a/packages/sdk/src/actions/index.ts
+++ b/packages/sdk/src/actions/index.ts
@@ -16,7 +16,6 @@ import type {
   RelayStatusRequest,
   RelayStatusResponseData,
   RequestOptions,
-  RoutesRequest,
   RoutesResponse,
   SignedLiFiStep,
   StatusResponse,
@@ -35,6 +34,7 @@ import type {
 import type {
   GetStatusRequestExtended,
   QuoteRequestFromAmount,
+  RoutesRequest,
 } from '../types/actions.js'
 import type { SDKClient } from '../types/core.js'
 import { getChains } from './getChains.js'

--- a/packages/sdk/src/types/actions.ts
+++ b/packages/sdk/src/types/actions.ts
@@ -8,8 +8,10 @@ export type GetStatusRequestExtended = GetStatusRequest & {
   fromAddress?: string
 }
 
-export type RoutesRequest = RoutesRequestBase & {
-  private?: boolean
+export type RoutesRequest = Omit<RoutesRequestBase, 'options'> & {
+  options?: RoutesRequestBase['options'] & {
+    private?: boolean
+  }
 }
 
 export type QuoteRequestFromAmount = QuoteRequestBase

--- a/packages/sdk/src/types/actions.ts
+++ b/packages/sdk/src/types/actions.ts
@@ -1,10 +1,15 @@
 import type {
   GetStatusRequest,
   QuoteRequest as QuoteRequestBase,
+  RoutesRequest as RoutesRequestBase,
 } from '@lifi/types'
 
 export type GetStatusRequestExtended = GetStatusRequest & {
   fromAddress?: string
+}
+
+export type RoutesRequest = RoutesRequestBase & {
+  private?: boolean
 }
 
 export type QuoteRequestFromAmount = QuoteRequestBase


### PR DESCRIPTION
## Which Linear task is linked to this PR?  
Part of https://linear.app/lifi-linear/issue/EMB-465/per-tab-config-for-header-navigation-tabs

## Why was it implemented this way?  
Adds a flag to pass to Jumper consumer backend API to differentiate private and non-private routes. 

Passed from here: https://github.com/lifinance/widget/pull/781/changes#diff-ee55dfe258ccd008d7b232b0bfe78ff7eef32468a14edc2faddb4c05156e2942R421 

## Checklist before requesting a review  
- [x] I have performed a self-review and testing of my code.  
- [x] This pull request is focused and addresses a single problem.  
- [ ] If this PR modifies the SDK API or adds new features that require documentation, I have updated the documentation in the [public-docs](https://github.com/lifinance/public-docs) repository.
