### PR TITLE
feat: export action param types (GetStatusRequestExtended, QuoteRequest family) from entrypoint

### DIFF
--- a/.changeset/export-get-status-request-extended.md
+++ b/.changeset/export-get-status-request-extended.md
@@ -1,0 +1,5 @@
+---
+'@lifi/sdk': patch
+---
+
+Export `getStatus`/`getQuote` param types from the entrypoint: `GetStatusRequestExtended`, `QuoteRequest`, `QuoteRequestFromAmount`, `QuoteRequestToAmount`.

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -68,6 +68,12 @@ export {
 export { HTTPError } from './errors/httpError.js'
 export { SDKError } from './errors/SDKError.js'
 export type {
+  GetStatusRequestExtended,
+  QuoteRequest,
+  QuoteRequestFromAmount,
+  QuoteRequestToAmount,
+} from './types/actions.js'
+export type {
   AcceptExchangeRateUpdateHook,
   AcceptSlippageUpdateHook,
   AcceptSlippageUpdateHookParams,


### PR DESCRIPTION
## What

Re-export the action **parameter types** from the `@lifi/sdk` package entrypoint (`src/index.ts`). They are all defined in `packages/sdk/src/types/actions.ts` but were never part of the public surface:

```ts
export type {
  GetStatusRequestExtended,
  QuoteRequest,
  QuoteRequestFromAmount,
  QuoteRequestToAmount,
} from './types/actions.js'
```

## Why

These are the parameter types of public actions, but consumers couldn't import them:

- **`GetStatusRequestExtended`** — the `getStatus` param (`GetStatusRequest & { fromAddress?: string }`).
- **`QuoteRequestFromAmount`, `QuoteRequestToAmount`** — the two `getQuote` overload param types.
- **`QuoteRequest`** — the union `QuoteRequestFromAmount | QuoteRequestToAmount` that `getQuote`'s implementation signature accepts.

`package.json` exposes only the `.` entrypoint, and none of these were re-exported from `src/index.ts`, so callers had to redefine them to type their `getStatus` / `getQuote` calls.

## Note on `QuoteRequest`

`@lifi/sdk` already re-exports `@lifi/types`' `QuoteRequest` (the base request **interface**) via `export * from '@lifi/types'`. The explicit named export added here **takes precedence** over that star re-export, so the public `@lifi/sdk` `QuoteRequest` now resolves to the **SDK union** instead of the base interface.

- This matches what `getQuote` actually accepts (it has `fromAmount` and `toAmount` overloads).
- **Non-breaking** for code that *constructs* a quote request (a base-shaped object still matches the `QuoteRequestFromAmount` arm).
- The only edge case is code that *reads* `fromAmount` off a value already typed as `QuoteRequest`, since the `QuoteRequestToAmount` arm omits it.

Changeset is **patch** (additive type exports). Let me know if you'd prefer a different bump.

## Verification

- `pnpm --filter @lifi/sdk check:types` — passes (the explicit `QuoteRequest` export overrides `export *` with no duplicate-identifier error)
- `biome check` — passes
- Built `dist/esm/index.d.ts` confirmed to import all four from `./types/actions.js` and re-export them; public `QuoteRequest` resolves to the SDK union
- `pnpm --filter @lifi/sdk-provider-sui test:unit` — passes (3 files, 10 tests) after building `@lifi/sdk`