### PR TITLE
fix(sdk): encode distributionFees query param in getQuote

### DIFF
--- a/.changeset/getquote-distributionfees-query.md
+++ b/.changeset/getquote-distributionfees-query.md
@@ -1,0 +1,5 @@
+---
+'@lifi/sdk': patch
+---
+
+Fix `getQuote` dropping `distributionFees` (and other nested array/object params). `getQuote` built its GET query string with `URLSearchParams`, which stringifies an array of objects to `[object Object]`, so multi-recipient fee splits never reached the backend (which parses query params with `qs.parse(..., { comma: true })`). A new `toQueryString` util encodes nested params in qs indices notation (`distributionFees[0][receiver]=...`), so `distributionFees` now serializes correctly on `/quote` and `/quote/toAmount`. Scalar and scalar-array params are unchanged.

--- a/packages/sdk/src/actions/actions.unit.handlers.ts
+++ b/packages/sdk/src/actions/actions.unit.handlers.ts
@@ -19,6 +19,9 @@ export const handlers = [
   ),
   http.get(`${client.config.apiUrl}/token`, async () => HttpResponse.json({})),
   http.get(`${client.config.apiUrl}/quote`, async () => HttpResponse.json({})),
+  http.get(`${client.config.apiUrl}/quote/toAmount`, async () =>
+    HttpResponse.json({})
+  ),
   http.get(`${client.config.apiUrl}/status`, async () => HttpResponse.json({})),
   http.get(`${client.config.apiUrl}/chains`, async () =>
     HttpResponse.json({ chains: [{ id: 1 }] })

--- a/packages/sdk/src/actions/getQuote.ts
+++ b/packages/sdk/src/actions/getQuote.ts
@@ -8,6 +8,7 @@ import type {
 } from '../types/actions.js'
 import type { SDKClient } from '../types/core.js'
 import { request } from '../utils/request.js'
+import { toQueryString } from '../utils/toQueryString.js'
 
 /**
  * Get a quote for a token transfer
@@ -95,8 +96,8 @@ export async function getQuote(
 
   return await request<LiFiStep>(
     client.config,
-    `${client.config.apiUrl}/${isFromAmountRequest ? 'quote' : 'quote/toAmount'}?${new URLSearchParams(
-      params as unknown as Record<string, string>
+    `${client.config.apiUrl}/${isFromAmountRequest ? 'quote' : 'quote/toAmount'}?${toQueryString(
+      params as Record<string, unknown>
     )}`,
     {
       signal: options?.signal,

--- a/packages/sdk/src/actions/getQuote.unit.spec.ts
+++ b/packages/sdk/src/actions/getQuote.unit.spec.ts
@@ -150,5 +150,56 @@ describe('getQuote', () => {
         expect(mockedFetch).toHaveBeenCalledTimes(1)
       })
     })
+
+    describe('and distributionFees are provided', () => {
+      const distributionFees = [
+        { percentage: 0.0005, receiver: '0xTenantA' },
+        { percentage: 0.001, receiver: '0xTenantB' },
+      ]
+
+      it('serializes distributionFees as qs indices notation on /quote', async () => {
+        await getQuote(client, {
+          fromChain,
+          fromToken,
+          fromAddress,
+          fromAmount,
+          toChain,
+          toToken,
+          distributionFees,
+        })
+
+        const url = mockedFetch.mock.calls[0][1] as string
+        expect(url.startsWith(`${client.config.apiUrl}/quote?`)).toBe(true)
+        // Scalar params still serialize as before
+        expect(url).toContain(`fromChain=${fromChain}`)
+        expect(url).toContain(`fromAmount=${fromAmount}`)
+        // Array-of-objects param is expressed in bracket-indices notation
+        expect(url).toContain(
+          'distributionFees[0][percentage]=0.0005&distributionFees[0][receiver]=0xTenantA&distributionFees[1][percentage]=0.001&distributionFees[1][receiver]=0xTenantB'
+        )
+        // and is NOT the broken [object Object] form
+        expect(url).not.toContain('object+Object')
+      })
+
+      it('serializes distributionFees on the /quote/toAmount path', async () => {
+        await getQuote(client, {
+          fromChain,
+          fromToken,
+          fromAddress,
+          toChain,
+          toToken,
+          toAmount,
+          distributionFees,
+        })
+
+        const url = mockedFetch.mock.calls[0][1] as string
+        expect(url.startsWith(`${client.config.apiUrl}/quote/toAmount?`)).toBe(
+          true
+        )
+        expect(url).toContain(
+          'distributionFees[0][percentage]=0.0005&distributionFees[0][receiver]=0xTenantA'
+        )
+      })
+    })
   })
 })

--- a/packages/sdk/src/utils/toQueryString.ts
+++ b/packages/sdk/src/utils/toQueryString.ts
@@ -1,0 +1,35 @@
+type QueryPrimitive = string | number | boolean | bigint
+
+const isPrimitive = (value: unknown): value is QueryPrimitive =>
+  typeof value === 'string' ||
+  typeof value === 'number' ||
+  typeof value === 'boolean' ||
+  typeof value === 'bigint'
+
+// Arrays of objects use qs indices notation (`key[0][subKey]=value`) to match
+// the backend's `qs.parse(str, { comma: true })`; only values are encoded.
+const serialize = (key: string, value: unknown): string[] => {
+  if (value === undefined || value === null) {
+    return []
+  }
+  if (isPrimitive(value)) {
+    return [`${key}=${encodeURIComponent(String(value))}`]
+  }
+  if (Array.isArray(value)) {
+    // Scalar arrays stay comma-joined (backend splits on `comma: true`).
+    if (value.every(isPrimitive)) {
+      return [`${key}=${encodeURIComponent(value.join(','))}`]
+    }
+    return value.flatMap((item, index) => serialize(`${key}[${index}]`, item))
+  }
+  return Object.entries(value as Record<string, unknown>).flatMap(
+    ([subKey, subValue]) => serialize(`${key}[${subKey}]`, subValue)
+  )
+}
+
+// Encode params into a query string (no leading `?`). Drop-in for
+// `URLSearchParams` that handles nested array/object params; skips null/undefined.
+export const toQueryString = (params: Record<string, unknown>): string =>
+  Object.entries(params)
+    .flatMap(([key, value]) => serialize(key, value))
+    .join('&')

--- a/packages/sdk/src/utils/toQueryString.unit.spec.ts
+++ b/packages/sdk/src/utils/toQueryString.unit.spec.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from 'vitest'
+import { toQueryString } from './toQueryString.js'
+
+describe('toQueryString', () => {
+  it('encodes scalar params (string, number, boolean)', () => {
+    expect(
+      toQueryString({
+        fromChain: 137,
+        fromToken: 'USDC',
+        allowDestinationCall: true,
+      })
+    ).toEqual('fromChain=137&fromToken=USDC&allowDestinationCall=true')
+  })
+
+  it('encodes scalar values', () => {
+    expect(toQueryString({ fromAddress: 'a b' })).toEqual('fromAddress=a%20b')
+  })
+
+  it('encodes bigint scalars', () => {
+    expect(toQueryString({ fromAmount: 1000000000n })).toEqual(
+      'fromAmount=1000000000'
+    )
+  })
+
+  it('comma-joins scalar arrays (backend qs.parse({ comma: true }) splits them)', () => {
+    expect(
+      toQueryString({ allowBridges: ['connext', 'uniswap', 'polygon'] })
+    ).toEqual('allowBridges=connext%2Cuniswap%2Cpolygon')
+  })
+
+  it('encodes arrays of objects in qs indices notation', () => {
+    expect(
+      toQueryString({
+        distributionFees: [
+          { percentage: 0.0005, receiver: '0xTenantA' },
+          { percentage: 0.001, receiver: '0xTenantB' },
+        ],
+      })
+    ).toEqual(
+      'distributionFees[0][percentage]=0.0005&distributionFees[0][receiver]=0xTenantA&distributionFees[1][percentage]=0.001&distributionFees[1][receiver]=0xTenantB'
+    )
+  })
+
+  it('skips undefined and null entries', () => {
+    expect(
+      toQueryString({
+        fromChain: 137,
+        toChain: undefined,
+        fromToken: null,
+        toToken: 'USDC',
+      })
+    ).toEqual('fromChain=137&toToken=USDC')
+  })
+
+  it('returns an empty string for an empty object', () => {
+    expect(toQueryString({})).toEqual('')
+  })
+})


### PR DESCRIPTION
## Problem

`getQuote` builds its GET query string with `new URLSearchParams(params)`, which stringifies an array of objects to the literal `[object Object]`. As a result, `distributionFees` (multi-recipient / N-way fee splits) was **silently dropped** on `/quote` and `/quote/toAmount` — TypeScript accepts the field (it's inherited from `@lifi/types` `QuoteRequest`), so callers got no signal it wasn't working. `getRoutes` is unaffected (POST JSON body).

The backend parses these GET params with `qs.parse(str, { comma: true })`, which expects array-of-object params in qs **indices** notation (`distributionFees[0][receiver]=…`) — something `URLSearchParams` can't express.

## Fix

Add a small, dependency-free `toQueryString` util that encodes nested array/object params in qs indices notation, and use it in `getQuote` in place of `URLSearchParams`. Scalar and scalar-array params serialize exactly as before; only nested params (like `distributionFees`) change.

- `packages/sdk/src/utils/toQueryString.ts` — new encoder (no new deps)
- `packages/sdk/src/actions/getQuote.ts` — one-line swap

## Scope

`getQuote` only (`/quote` + `/quote/toAmount`). `getRelayerQuote` has the same `URLSearchParams` pattern and accepts `distributionFees` too — intentionally left out of this PR; the new util makes it a one-line follow-up.

## Verification

- ✅ Unit tests: new `toQueryString.unit.spec.ts` + extended `getQuote.unit.spec.ts` (both quote paths); full `@lifi/sdk` suite green, types + biome + circular-deps + knip clean.
- ✅ **Live end-to-end** against the API with `integrator: fee-demo` + `distributionFees`: the quote succeeds and the response returns the expected `Fee Forward` fee-cost entries, each with a `DISTRIBUTION` recipient and correct amounts (0.05% → `500000`, 0.10% → `1000000` of 1000 USDC).

## Changeset

Included — `@lifi/sdk` patch.