### PR TITLE
chore(ci): bump pinned GitHub Action versions

### DIFF
--- a/.github/actions/pnpm-install/action.yaml
+++ b/.github/actions/pnpm-install/action.yaml
@@ -12,7 +12,7 @@ runs:
   using: 'composite'
   steps:
     - name: Set up pnpm
-      uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
+      uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
     - name: Set up Node.js
       uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
       with:

--- a/.github/workflows/linear-release.yaml
+++ b/.github/workflows/linear-release.yaml
@@ -47,14 +47,14 @@ jobs:
           echo "release_tag=${PACKAGE}@${FULL}" >> "$GITHUB_OUTPUT"
           echo "Resolved $PACKAGE $FULL -> version=$VERSION channel=$CHANNEL"
 
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
           fetch-tags: true
           persist-credentials: false
 
       - name: Sync issues to release
-        uses: linear/linear-release-action@ad7da502eec3a93dd17e2e249e6c1cd84e3ee588 # v0.14.0
+        uses: linear/linear-release-action@c0cb8354a362c24c6d3e0948f37fd66d07588e3f # v0.14.5
         with:
           access_key: ${{ secrets.access_key }}
           command: sync
@@ -66,7 +66,7 @@ jobs:
       # prerelease: advance the stage; the release stays open
       - name: Advance stage (alpha/beta)
         if: steps.meta.outputs.channel != 'stable'
-        uses: linear/linear-release-action@ad7da502eec3a93dd17e2e249e6c1cd84e3ee588 # v0.14.0
+        uses: linear/linear-release-action@c0cb8354a362c24c6d3e0948f37fd66d07588e3f # v0.14.5
         with:
           access_key: ${{ secrets.access_key }}
           command: update
@@ -76,7 +76,7 @@ jobs:
       # stable: complete the release (fires the "→ Done" automation)
       - name: Complete release (stable)
         if: steps.meta.outputs.channel == 'stable'
-        uses: linear/linear-release-action@ad7da502eec3a93dd17e2e249e6c1cd84e3ee588 # v0.14.0
+        uses: linear/linear-release-action@c0cb8354a362c24c6d3e0948f37fd66d07588e3f # v0.14.5
         with:
           access_key: ${{ secrets.access_key }}
           command: complete

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -41,7 +41,7 @@ jobs:
       hasChangesets: ${{ steps.changesets.outputs.hasChangesets }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           # Full history so Changesets can build correct changelogs.
           fetch-depth: 0
@@ -53,7 +53,7 @@ jobs:
 
       - name: Create version PR
         id: changesets
-        uses: changesets/action@63a615b9cd06ba9a3e6d13796c7fbcb080a60a0b # v1.8.0
+        uses: changesets/action@a45c4d594aa4e2c509dc14a9f2b3b67ba3780d0d # v1.9.0
         with:
           version: pnpm changeset:version
           title: 'chore: version packages'
@@ -75,7 +75,7 @@ jobs:
       publishedPackages: ${{ steps.changesets.outputs.publishedPackages }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
 
@@ -86,7 +86,7 @@ jobs:
 
       - name: Publish to npm
         id: changesets
-        uses: changesets/action@63a615b9cd06ba9a3e6d13796c7fbcb080a60a0b # v1.8.0
+        uses: changesets/action@a45c4d594aa4e2c509dc14a9f2b3b67ba3780d0d # v1.9.0
         with:
           publish: pnpm changeset:publish
           createGithubReleases: true
@@ -128,7 +128,7 @@ jobs:
       pull-requests: write # post the install comment + remove the label
     steps:
       - name: Checkout PR head
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -21,7 +21,7 @@ jobs:
         os:
           - ubuntu-latest
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Install dependencies
         uses: ./.github/actions/pnpm-install
       - name: Lint and format check


### PR DESCRIPTION
## What

Bumps all pinned GitHub Action versions used across our workflows and composite actions to their latest releases. All actions stay SHA-pinned with a trailing `# vX.Y.Z` version comment.

| Action | Before | After | Type |
|---|---|---|---|
| `actions/checkout` | v6.0.2 | **v7.0.0** | major |
| `changesets/action` | v1.8.0 | **v1.9.0** | minor |
| `pnpm/action-setup` | v6.0.8 | **v6.0.9** | patch |
| `linear/linear-release-action` | v0.14.0 | **v0.14.5** | patch |
| `actions/setup-node` | v6.4.0 | v6.4.0 | already latest — unchanged |

## Why

Routine maintenance. Prompted by a transient `changeset version` failure (a "Premature close" network blip against GitHub's GraphQL API — not a version bug, resolved by re-running). While verifying that, noticed several actions were a release or two behind, so this brings them current.

## Notes on the bumps

- **`actions/checkout` v6 → v7** (major): per the [release notes](https://github.com/actions/checkout/releases/tag/v7.0.0), the only behavioral change is blocking fork-PR checkout for `pull_request_target` / `workflow_run` events (security hardening); the rest is an ESM module upgrade + dependency bumps. None of our workflows use `pull_request_target`, so no impact.
- **`changesets/action` v1.8 → v1.9** (minor): adds optional `pr-comment`/`pr-status` sub-actions and includes reliability fixes for force-pushed version PRs and GitHub Release creation. No config change needed for our usage.

## Files

- `.github/workflows/publish.yaml`
- `.github/workflows/tests.yaml`
- `.github/workflows/linear-release.yaml`
- `.github/actions/pnpm-install/action.yaml`

No changeset — CI/config-only change (per repo policy).