### PR TITLE
chore(ci): bump CI Node 24 → 26 

### DIFF
--- a/.github/actions/pnpm-install/action.yaml
+++ b/.github/actions/pnpm-install/action.yaml
@@ -16,7 +16,7 @@ runs:
     - name: Set up Node.js
       uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
       with:
-        node-version: '24'
+        node-version: '26'
         registry-url: 'https://registry.npmjs.org'
         # '' disables caching entirely (no restore, no save) for privileged jobs.
         cache: ${{ inputs.cache == 'true' && 'pnpm' || '' }}


### PR DESCRIPTION
## What

Bumps the CI Node version from **24 → 26** in the shared `pnpm-install` composite action (the single place `node-version` is pinned).

## Why

The `Version` job (changesets `Create version PR`) has been failing repeatedly today with:

```
🦋  error  Failed to parse data from GitHub
🦋  error  Invalid response body while trying to fetch https://api.github.com/graphql: Premature close
   at .../@changesets/get-github-info@0.8.0/.../changesets-get-github-info.cjs.js:185:11
```

Diagnosis so far:
- **Not a GitHub outage** — status is operational, and the *exact* `get-github-info` GraphQL query (commit → `associatedPullRequests` → author, for all 5 pending changesets) succeeds **reliably from outside the runner**.
- **Not payload size** (only 5 changesets) and **not rate-limiting** (rate limit healthy).
- Re-running the job **failed 3× in a row**, so it's no longer a one-off blip — it reproduces *only on the GitHub-hosted runner*.

That points at an intermittent **Node 24 HTTP-client (undici) "Premature close"** when talking to GitHub's GraphQL API from the runner. Node 26 ships a newer undici, so this is the cheapest thing to try.

## Honest caveat

This is **unproven** — I can't reproduce the failure outside the runner, so I can't validate the fix locally. The real test is whether the `Version` job goes green on the next push to `main` after merge (the changeset step only runs on push, not on this PR).

## Blast radius

`pnpm-install` is used by **all** CI jobs, so this also moves build / test / publish to Node 26. This PR's own `Tests` check exercises build + test under Node 26 — a green check here validates the toolchain works on 26. pnpm 11.8.0 supports Node 26; the repo has no `engines.node` / `engine-strict` constraint.

## If this doesn't fix it

Fall back to wrapping `changeset version` in a retry (handles isolated blips) or temporarily bypassing the GitHub changelog enrichment for one release.