### PR TITLE
chore: add changeset for package bump (#418)

### DIFF
--- a/.changeset/bump-packages.md
+++ b/.changeset/bump-packages.md
@@ -1,0 +1,6 @@
+---
+"@lifi/sdk-provider-sui": patch
+"@lifi/sdk-provider-tron": patch
+---
+
+Bump runtime dependencies: @mysten/sui to 2.20.1 and tronweb to 6.4.0.


### PR DESCRIPTION
Follow-up to #418, which was merged before its changeset was added.

PR #418 bumped runtime dependencies in two published packages but landed without a changeset, so no version bump / release would be generated for them. This adds the missing changeset:

- `@lifi/sdk-provider-sui` (patch) — `@mysten/sui` 2.19.0 → 2.20.1
- `@lifi/sdk-provider-tron` (patch) — `tronweb` 6.3.0 → 6.4.0

The other bumps in #418 (`@lifi/data-types`, `@types/node`, biome, commitlint, knip, pnpm) are devDependencies/tooling and intentionally have no changeset entry, consistent with prior bump PRs (#402, #406).

Merging this will let the Changesets bot open a Version Packages PR releasing the two providers.