### PR TITLE
fix(ethereum): handle nullish native permit signatures (#424)

### DIFF
--- a/.changeset/nullish-permit-signature.md
+++ b/.changeset/nullish-permit-signature.md
@@ -1,0 +1,5 @@
+---
+"@lifi/sdk-provider-ethereum": patch
+---
+
+Handle wallets that resolve `signTypedData` with a nullish or empty signature instead of rejecting (#424). The EIP-2612 native permit flow now falls back to the Permit2/standard approval path instead of crashing later with `TypeError: Cannot read properties of null (reading 'slice')`, and the other signing flows (API permits, relayed intents, Permit2 messages) throw a descriptive `SignatureRejected` error. Permit lookups also ignore stored entries without a usable signature.

--- a/packages/sdk-provider-ethereum/src/core/tasks/EthereumCheckPermitsTask.ts
+++ b/packages/sdk-provider-ethereum/src/core/tasks/EthereumCheckPermitsTask.ts
@@ -7,6 +7,7 @@ import { signTypedData } from 'viem/actions'
 import { getAction } from 'viem/utils'
 import type { EthereumStepExecutorContext } from '../../types.js'
 import { getDomainChainId } from '../../utils/getDomainChainId.js'
+import { assertValidSignature } from '../../utils/isValidSignature.js'
 
 export class EthereumCheckPermitsTask extends BaseStepExecutionTask {
   override async shouldRun(
@@ -71,6 +72,7 @@ export class EthereumCheckPermitsTask extends BaseStepExecutionTask {
         primaryType: typedData.primaryType,
         message: typedData.message,
       })
+      assertValidSignature(signature)
       const signedPermit: SignedTypedData = {
         ...typedData,
         signature,

--- a/packages/sdk-provider-ethereum/src/core/tasks/EthereumCheckPermitsTask.unit.spec.ts
+++ b/packages/sdk-provider-ethereum/src/core/tasks/EthereumCheckPermitsTask.unit.spec.ts
@@ -1,0 +1,94 @@
+import {
+  LiFiErrorCode,
+  type LiFiStep,
+  type SignedTypedData,
+  type TypedData,
+} from '@lifi/sdk'
+import type { Address, Hex } from 'viem'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('viem/actions', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('viem/actions')>()
+  return {
+    ...actual,
+    signTypedData: vi.fn(),
+  }
+})
+
+import { signTypedData } from 'viem/actions'
+import type { EthereumStepExecutorContext } from '../../types.js'
+import { EthereumCheckPermitsTask } from './EthereumCheckPermitsTask.js'
+
+const SOURCE_CHAIN = 1
+const FROM_ADDRESS = '0xaaaa000000000000000000000000000000000001' as Address
+const SIGNATURE = `0x${'11'.repeat(65)}` as Hex
+
+const buildPermitTypedData = (): TypedData =>
+  ({
+    primaryType: 'Permit',
+    domain: { chainId: SOURCE_CHAIN },
+    types: {},
+    message: {
+      owner: FROM_ADDRESS,
+      spender: '0xbbbb000000000000000000000000000000000002',
+      value: '1000000',
+      nonce: '0',
+      deadline: String(Math.floor(Date.now() / 1000) + 3600),
+    },
+  }) as TypedData
+
+const buildContext = (): EthereumStepExecutorContext => {
+  const step = {
+    type: 'lifi',
+    id: 'step-1',
+    tool: 'lifi',
+    action: { fromChainId: SOURCE_CHAIN, fromAddress: FROM_ADDRESS },
+    estimate: { gasCosts: [], feeCosts: [] },
+    typedData: [buildPermitTypedData()],
+  } as unknown as LiFiStep
+  return {
+    step,
+    statusManager: {
+      initializeAction: vi.fn().mockReturnValue({ type: 'PERMIT' }),
+      updateAction: vi.fn(),
+    },
+    allowUserInteraction: true,
+    checkClient: vi.fn().mockResolvedValue({
+      account: { address: FROM_ADDRESS },
+    }),
+    signedTypedData: [],
+  } as unknown as EthereumStepExecutorContext
+}
+
+const task = new EthereumCheckPermitsTask()
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+describe('EthereumCheckPermitsTask.run', () => {
+  it('throws SignatureRejected when the wallet resolves signTypedData with null', async () => {
+    vi.mocked(signTypedData).mockResolvedValue(null as unknown as Hex)
+    const context = buildContext()
+
+    await expect(task.run(context)).rejects.toMatchObject({
+      name: 'TransactionError',
+      code: LiFiErrorCode.SignatureRejected,
+    })
+    expect(context.signedTypedData).toHaveLength(0)
+  })
+
+  it('stores the signed permit and sets hasMatchingPermit for a valid signature', async () => {
+    vi.mocked(signTypedData).mockResolvedValue(SIGNATURE)
+    const context = buildContext()
+
+    const result = await task.run(context)
+    const resultContext = result.context as
+      | { hasMatchingPermit?: boolean; signedTypedData?: SignedTypedData[] }
+      | undefined
+
+    expect(result.status).toBe('COMPLETED')
+    expect(resultContext?.hasMatchingPermit).toBe(true)
+    expect(resultContext?.signedTypedData?.[0].signature).toBe(SIGNATURE)
+  })
+})

--- a/packages/sdk-provider-ethereum/src/core/tasks/EthereumNativePermitTask.ts
+++ b/packages/sdk-provider-ethereum/src/core/tasks/EthereumNativePermitTask.ts
@@ -10,6 +10,7 @@ import { getNativePermit } from '../../permits/getNativePermit.js'
 import { isNativePermitValid } from '../../permits/isNativePermitValid.js'
 import type { EthereumStepExecutorContext } from '../../types.js'
 import { getActionWithFallback } from '../../utils/getActionWithFallback.js'
+import { isValidSignature } from '../../utils/isValidSignature.js'
 import { getEthereumExecutionStrategy } from './helpers/getEthereumExecutionStrategy.js'
 
 export class EthereumNativePermitTask extends BaseStepExecutionTask {
@@ -110,6 +111,14 @@ export class EthereumNativePermitTask extends BaseStepExecutionTask {
         primaryType: nativePermitData.primaryType,
         message: nativePermitData.message,
       })
+
+      // Some wallets resolve signTypedData with a nullish or empty value
+      // instead of rejecting — skip the permit and fall back to the
+      // Permit2/standard approval flow
+      if (!isValidSignature(signature)) {
+        statusManager.updateAction(step, action.type, 'DONE')
+        return { status: 'COMPLETED' }
+      }
 
       // Add the new permit to the signed permits array
       const signedPermit: SignedTypedData = {

--- a/packages/sdk-provider-ethereum/src/core/tasks/EthereumNativePermitTask.unit.spec.ts
+++ b/packages/sdk-provider-ethereum/src/core/tasks/EthereumNativePermitTask.unit.spec.ts
@@ -1,0 +1,164 @@
+import type { LiFiStep, SignedTypedData, TypedData } from '@lifi/sdk'
+import type { Address, Hex } from 'viem'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('../../utils/getActionWithFallback.js', () => ({
+  getActionWithFallback: vi.fn(),
+}))
+
+vi.mock('viem/actions', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('viem/actions')>()
+  return {
+    ...actual,
+    signTypedData: vi.fn(),
+  }
+})
+
+import { signTypedData } from 'viem/actions'
+import type { EthereumStepExecutorContext } from '../../types.js'
+import { getActionWithFallback } from '../../utils/getActionWithFallback.js'
+import { EthereumNativePermitTask } from './EthereumNativePermitTask.js'
+
+const SOURCE_CHAIN = 1
+const FROM_ADDRESS = '0xaaaa000000000000000000000000000000000001' as Address
+const TOKEN_ADDRESS = '0xcccc000000000000000000000000000000000003' as Address
+const PERMIT2_PROXY = '0xdddd000000000000000000000000000000000004' as Address
+const SIGNATURE = `0x${'11'.repeat(65)}` as Hex
+
+const buildNativePermitData = (): TypedData =>
+  ({
+    primaryType: 'Permit',
+    domain: {
+      name: 'USD Coin',
+      version: '2',
+      chainId: SOURCE_CHAIN,
+      verifyingContract: TOKEN_ADDRESS,
+    },
+    types: {},
+    message: {
+      owner: FROM_ADDRESS,
+      spender: PERMIT2_PROXY,
+      value: '1000000',
+      nonce: '0',
+      deadline: String(Math.floor(Date.now() / 1000) + 3600),
+    },
+  }) as TypedData
+
+const buildStep = (): LiFiStep =>
+  ({
+    type: 'lifi',
+    id: 'step-1',
+    tool: 'lifi',
+    action: {
+      fromChainId: SOURCE_CHAIN,
+      fromAddress: FROM_ADDRESS,
+      fromAmount: '1000000',
+      fromToken: { address: TOKEN_ADDRESS, chainId: SOURCE_CHAIN },
+    },
+    estimate: { gasCosts: [], feeCosts: [] },
+  }) as unknown as LiFiStep
+
+const buildContext = (overrides?: {
+  signedTypedData?: SignedTypedData[]
+}): {
+  context: EthereumStepExecutorContext
+  updateAction: ReturnType<typeof vi.fn>
+} => {
+  const updateAction = vi.fn()
+  const context = {
+    step: buildStep(),
+    client: {},
+    fromChain: { id: SOURCE_CHAIN, permit2Proxy: PERMIT2_PROXY },
+    statusManager: {
+      initializeAction: vi.fn().mockReturnValue({ type: 'NATIVE_PERMIT' }),
+      updateAction,
+    },
+    allowUserInteraction: true,
+    // The client stub must not carry its own signTypedData method so
+    // getAction falls through to the mocked viem action
+    checkClient: vi.fn().mockResolvedValue({
+      account: { address: FROM_ADDRESS },
+    }),
+    signedTypedData: overrides?.signedTypedData ?? [],
+  } as unknown as EthereumStepExecutorContext
+  return { context, updateAction }
+}
+
+type PermitTaskContext =
+  | {
+      hasMatchingPermit?: boolean
+      signedTypedData?: SignedTypedData[]
+    }
+  | undefined
+
+const task = new EthereumNativePermitTask()
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  vi.mocked(getActionWithFallback).mockResolvedValue(buildNativePermitData())
+})
+
+describe('EthereumNativePermitTask.run', () => {
+  it('falls back to the approval flow when the wallet resolves signTypedData with null (issue #424)', async () => {
+    vi.mocked(signTypedData).mockResolvedValue(null as unknown as Hex)
+    const { context, updateAction } = buildContext()
+
+    const result = await task.run(context)
+
+    // Completes without claiming a permit so ResetAllowance/SetAllowance run
+    expect(result.status).toBe('COMPLETED')
+    expect(result.context).toBeUndefined()
+    expect(context.signedTypedData).toHaveLength(0)
+    expect(updateAction).toHaveBeenLastCalledWith(
+      context.step,
+      'NATIVE_PERMIT',
+      'DONE'
+    )
+  })
+
+  it('stores the permit and sets hasMatchingPermit for a valid signature', async () => {
+    vi.mocked(signTypedData).mockResolvedValue(SIGNATURE)
+    const { context } = buildContext()
+
+    const result = await task.run(context)
+    const resultContext = result.context as PermitTaskContext
+
+    expect(result.status).toBe('COMPLETED')
+    expect(resultContext?.hasMatchingPermit).toBe(true)
+    expect(resultContext?.signedTypedData).toHaveLength(1)
+    expect(resultContext?.signedTypedData?.[0].signature).toBe(SIGNATURE)
+  })
+
+  it('skips signing when a valid matching permit already exists', async () => {
+    const existingPermit: SignedTypedData = {
+      ...buildNativePermitData(),
+      signature: SIGNATURE,
+    }
+    const { context } = buildContext({ signedTypedData: [existingPermit] })
+
+    const result = await task.run(context)
+    const resultContext = result.context as PermitTaskContext
+
+    expect(signTypedData).not.toHaveBeenCalled()
+    expect(resultContext?.hasMatchingPermit).toBe(true)
+    expect(resultContext?.signedTypedData).toHaveLength(1)
+  })
+
+  it('re-signs when an existing matching permit has a nullish signature', async () => {
+    vi.mocked(signTypedData).mockResolvedValue(SIGNATURE)
+    const stalePermit: SignedTypedData = {
+      ...buildNativePermitData(),
+      signature: null as unknown as Hex,
+    }
+    const { context } = buildContext({ signedTypedData: [stalePermit] })
+
+    const result = await task.run(context)
+    const resultContext = result.context as PermitTaskContext
+
+    expect(signTypedData).toHaveBeenCalledTimes(1)
+    expect(resultContext?.hasMatchingPermit).toBe(true)
+    expect(
+      resultContext?.signedTypedData?.filter((item) => item.signature)
+    ).toHaveLength(1)
+  })
+})

--- a/packages/sdk-provider-ethereum/src/core/tasks/EthereumRelayedSignAndExecuteTask.ts
+++ b/packages/sdk-provider-ethereum/src/core/tasks/EthereumRelayedSignAndExecuteTask.ts
@@ -12,6 +12,7 @@ import { isHyperliquidAgentStep } from '../../hyperliquid/isHyperliquidAgentStep
 import { isNativePermitValid } from '../../permits/isNativePermitValid.js'
 import type { EthereumStepExecutorContext } from '../../types.js'
 import { getDomainChainId } from '../../utils/getDomainChainId.js'
+import { assertValidSignature } from '../../utils/isValidSignature.js'
 import { signHyperliquidTypedData } from './helpers/signHyperliquidTypedData.js'
 
 export class EthereumRelayedSignAndExecuteTask extends BaseStepExecutionTask {
@@ -93,6 +94,8 @@ export class EthereumRelayedSignAndExecuteTask extends BaseStepExecutionTask {
           types: typedData.types,
           message: typedData.message,
         })
+
+        assertValidSignature(signature)
 
         signedTypedData.push({
           ...typedData,

--- a/packages/sdk-provider-ethereum/src/core/tasks/EthereumStandardSignAndExecuteTask.ts
+++ b/packages/sdk-provider-ethereum/src/core/tasks/EthereumStandardSignAndExecuteTask.ts
@@ -14,6 +14,7 @@ import { signPermit2Message } from '../../permits/signPermit2Message.js'
 import type { EthereumStepExecutorContext } from '../../types.js'
 import { convertExtendedChain } from '../../utils/convertExtendedChain.js'
 import { getDomainChainId } from '../../utils/getDomainChainId.js'
+import { isValidSignature } from '../../utils/isValidSignature.js'
 import { estimateTransactionRequest } from './helpers/estimateTransactionRequest.js'
 import { getTxLink } from './helpers/getTxLink.js'
 import { isPermit2Supported } from './helpers/isPermit2Supported.js'
@@ -68,7 +69,8 @@ export class EthereumStandardSignAndExecuteTask extends BaseStepExecutionTask {
     const signedNativePermitTypedData = signedTypedData.find(
       (p) =>
         p.primaryType === 'Permit' &&
-        getDomainChainId(p.domain) === fromChain.id
+        getDomainChainId(p.domain) === fromChain.id &&
+        isValidSignature(p.signature)
     )
     if (signedNativePermitTypedData) {
       transactionRequest.data = encodeNativePermitData(

--- a/packages/sdk-provider-ethereum/src/core/tasks/helpers/signHyperliquidTypedData.ts
+++ b/packages/sdk-provider-ethereum/src/core/tasks/helpers/signHyperliquidTypedData.ts
@@ -9,6 +9,7 @@ import {
 } from '../../../hyperliquid/isHyperliquidAgentStep.js'
 import type { EthereumStepExecutorContext } from '../../../types.js'
 import { getDomainChainId } from '../../../utils/getDomainChainId.js'
+import { assertValidSignature } from '../../../utils/isValidSignature.js'
 
 export const signHyperliquidTypedData = async (
   context: EthereumStepExecutorContext,
@@ -73,6 +74,7 @@ export const signHyperliquidTypedData = async (
         types: typedData.types,
         message,
       })
+      assertValidSignature(signature)
       signedResults.push({ ...typedData, message, signature })
     } else if (isApproveBuilderFeeMessage(typedData)) {
       const typedDataChainId =
@@ -94,6 +96,7 @@ export const signHyperliquidTypedData = async (
         types: typedData.types,
         message: typedData.message,
       })
+      assertValidSignature(signature)
       signedResults.push({ ...typedData, signature })
     } else if (isHyperliquidOrderMessage(typedData)) {
       const signature = await agentAccount.signTypedData({

--- a/packages/sdk-provider-ethereum/src/permits/isNativePermitValid.ts
+++ b/packages/sdk-provider-ethereum/src/permits/isNativePermitValid.ts
@@ -1,4 +1,5 @@
 import type { SignedTypedData, TypedData } from '@lifi/sdk'
+import { isValidSignature } from '../utils/isValidSignature.js'
 
 /**
  * Checks if an existing native permit is valid for the given requirements
@@ -7,6 +8,11 @@ export const isNativePermitValid = (
   permit: SignedTypedData,
   typedData: TypedData
 ): boolean => {
+  // Check if the permit has a usable signature
+  if (!isValidSignature(permit.signature)) {
+    return false
+  }
+
   // Only check native permits (EIP-2612)
   if (permit.primaryType !== 'Permit') {
     return false

--- a/packages/sdk-provider-ethereum/src/permits/isNativePermitValid.unit.spec.ts
+++ b/packages/sdk-provider-ethereum/src/permits/isNativePermitValid.unit.spec.ts
@@ -1,0 +1,45 @@
+import type { SignedTypedData, TypedData } from '@lifi/sdk'
+import type { Hex } from 'viem'
+import { describe, expect, it } from 'vitest'
+import { isNativePermitValid } from './isNativePermitValid.js'
+
+const OWNER = '0xaaaa000000000000000000000000000000000001'
+const SPENDER = '0xbbbb000000000000000000000000000000000002'
+const SIGNATURE = `0x${'11'.repeat(65)}` as Hex
+
+const buildTypedData = (): TypedData =>
+  ({
+    primaryType: 'Permit',
+    domain: { chainId: 1 },
+    types: {},
+    message: {
+      owner: OWNER,
+      spender: SPENDER,
+      value: '1000000',
+      nonce: '0',
+      deadline: String(Math.floor(Date.now() / 1000) + 3600),
+    },
+  }) as TypedData
+
+const buildPermit = (signature: Hex): SignedTypedData => ({
+  ...buildTypedData(),
+  signature,
+})
+
+describe('isNativePermitValid', () => {
+  it('accepts a matching permit with a valid signature', () => {
+    expect(isNativePermitValid(buildPermit(SIGNATURE), buildTypedData())).toBe(
+      true
+    )
+  })
+
+  it.each([
+    ['null', null],
+    ['undefined', undefined],
+    ['empty hex', '0x'],
+  ])('rejects a matching permit with a %s signature', (_, signature) => {
+    expect(
+      isNativePermitValid(buildPermit(signature as Hex), buildTypedData())
+    ).toBe(false)
+  })
+})

--- a/packages/sdk-provider-ethereum/src/permits/signPermit2Message.ts
+++ b/packages/sdk-provider-ethereum/src/permits/signPermit2Message.ts
@@ -3,6 +3,7 @@ import type { Address, Client, Hex } from 'viem'
 import { keccak256 } from 'viem'
 import { signTypedData } from 'viem/actions'
 import { getAction } from 'viem/utils'
+import { assertValidSignature } from '../utils/isValidSignature.js'
 import { getPermitTransferFromValues } from './getPermitTransferFromValues.js'
 import { getPermitData } from './signatureTransfer.js'
 
@@ -75,6 +76,8 @@ export async function signPermit2Message(
     types: permitData.types,
     message: permitData.message,
   })
+
+  assertValidSignature(signature)
 
   return {
     ...permitData,

--- a/packages/sdk-provider-ethereum/src/utils/isValidSignature.ts
+++ b/packages/sdk-provider-ethereum/src/utils/isValidSignature.ts
@@ -1,0 +1,26 @@
+import { LiFiErrorCode, TransactionError } from '@lifi/sdk'
+import { type Hex, isHex } from 'viem'
+
+/**
+ * Checks that a wallet-returned signature is a usable hex string.
+ * Some wallets can resolve `signTypedData` with a nullish or empty ('0x')
+ * value instead of rejecting.
+ * Signature length is intentionally not validated: 65-byte, EIP-2098 compact
+ * and arbitrary-length smart account (ERC-1271) signatures are all valid.
+ */
+export function isValidSignature(
+  signature: Hex | null | undefined
+): signature is Hex {
+  return isHex(signature) && signature !== '0x'
+}
+
+export function assertValidSignature(
+  signature: Hex | null | undefined
+): asserts signature is Hex {
+  if (!isValidSignature(signature)) {
+    throw new TransactionError(
+      LiFiErrorCode.SignatureRejected,
+      'Wallet did not return a valid signature.'
+    )
+  }
+}

--- a/packages/sdk-provider-ethereum/src/utils/isValidSignature.unit.spec.ts
+++ b/packages/sdk-provider-ethereum/src/utils/isValidSignature.unit.spec.ts
@@ -1,0 +1,42 @@
+import { LiFiErrorCode } from '@lifi/sdk'
+import type { Hex } from 'viem'
+import { describe, expect, it } from 'vitest'
+import { assertValidSignature, isValidSignature } from './isValidSignature.js'
+
+const SIG_65_BYTES = `0x${'11'.repeat(65)}` as Hex
+const SIG_64_BYTES_COMPACT = `0x${'11'.repeat(64)}` as Hex
+const SIG_SMART_ACCOUNT = `0x${'11'.repeat(300)}` as Hex
+
+describe('isValidSignature', () => {
+  it.each([
+    [null, false],
+    [undefined, false],
+    ['0x', false],
+    ['not-hex', false],
+    [SIG_65_BYTES, true],
+    // EIP-2098 compact signature
+    [SIG_64_BYTES_COMPACT, true],
+    // Smart account (ERC-1271) signatures can be arbitrary length
+    [SIG_SMART_ACCOUNT, true],
+  ] as [
+    Hex | null | undefined,
+    boolean,
+  ][])('isValidSignature(%s) → %s', (signature, expected) => {
+    expect(isValidSignature(signature)).toBe(expected)
+  })
+})
+
+describe('assertValidSignature', () => {
+  it('throws a TransactionError with the SignatureRejected code for a nullish signature', () => {
+    expect(() => assertValidSignature(null)).toThrowError(
+      expect.objectContaining({
+        name: 'TransactionError',
+        code: LiFiErrorCode.SignatureRejected,
+      })
+    )
+  })
+
+  it('does not throw for a valid signature', () => {
+    expect(() => assertValidSignature(SIG_65_BYTES)).not.toThrow()
+  })
+})


### PR DESCRIPTION
## Summary

Fixes #424. Some wallets (observed with Rabby on Edge/Windows) resolve `eth_signTypedData_v4` with a nullish or empty (`'0x'`) value instead of throwing a rejection. The signature was stored unvalidated and later crashed while building the transaction:

```
TypeError: Cannot read properties of null (reading 'slice')
```

The raw error surfaced to users (with the allowance step already shown as "done"), and because execution auto-resumes in-flight routes, retrying re-hit the same wall — the route became unrecoverable.

## Changes

- **New `utils/isValidSignature.ts`** — `isValidSignature` predicate (viem `isHex` + empty-`'0x'` exclusion; length intentionally not validated so 65-byte, EIP-2098 compact, and ERC-1271 signatures all pass) and an `assertValidSignature` that throws `TransactionError(SignatureRejected)`.
- **`EthereumNativePermitTask`** — on an invalid signature, does not store the permit and does not set `hasMatchingPermit`, so the pipeline gracefully falls back to the Permit2/standard approval path instead of crashing.
- **Throwing guards** at the signing sites with no fallback — `EthereumCheckPermitsTask`, `EthereumRelayedSignAndExecuteTask`, `signPermit2Message`, and the wallet-driven Hyperliquid sites — surface a descriptive `SignatureRejected` error, consistent with how wallet rejections are already handled.
- **Defense-in-depth** — `isNativePermitValid` and the native-permit lookup in `EthereumStandardSignAndExecuteTask` ignore entries without a usable signature.

## Trade-off

On Permit2-capable chains, if a wallet also nulls the subsequent Permit2 signature, the fallback throws `SignatureRejected` only after the approval transaction gas is spent. This is deliberate: throwing on the permit itself would deadlock the route permanently (auto-resume re-signs and gets `null` again), whereas the fallback keeps the route completable.

## Tests

19 new unit tests across 4 spec files (helper, `isNativePermitValid`, `EthereumNativePermitTask` fallback, `EthereumCheckPermitsTask` throw), following the existing task-spec pattern. Full provider suite, biome, `tsc`, knip, and circular-deps all pass.
