### PR TITLE
feat(sdk): forward svmPriorityFeeLevel to stepTransaction for Solana steps

### DIFF
--- a/.changeset/forward-svm-priority-fee-level.md
+++ b/.changeset/forward-svm-priority-fee-level.md
@@ -1,0 +1,5 @@
+---
+"@lifi/sdk": minor
+---
+
+Forward `routeOptions.svmPriorityFeeLevel` (`NORMAL` | `FAST` | `ULTRA`) to `/advanced/stepTransaction` for Solana steps, letting integrators pick the priority-fee tier used when building Solana transactions.

--- a/packages/sdk/src/actions/getStepTransaction.ts
+++ b/packages/sdk/src/actions/getStepTransaction.ts
@@ -28,6 +28,7 @@ export const getStepTransaction = async (
   let requestUrl = `${config.apiUrl}/advanced/stepTransaction`
   const jitoBundle = config.routeOptions?.jitoBundle
   const svmSponsor = config.routeOptions?.svmSponsor
+  const svmPriorityFeeLevel = config.routeOptions?.svmPriorityFeeLevel
 
   if (step.action.fromChainId === ChainId.SOL) {
     const queryParams = new URLSearchParams()
@@ -36,6 +37,9 @@ export const getStepTransaction = async (
     }
     if (svmSponsor) {
       queryParams.set('svmSponsor', svmSponsor)
+    }
+    if (svmPriorityFeeLevel) {
+      queryParams.set('svmPriorityFeeLevel', svmPriorityFeeLevel)
     }
     if (queryParams.size > 0) {
       requestUrl = `${requestUrl}?${queryParams}`

--- a/packages/sdk/src/actions/getStepTransaction.unit.spec.ts
+++ b/packages/sdk/src/actions/getStepTransaction.unit.spec.ts
@@ -1,7 +1,8 @@
 import { findDefaultToken } from '@lifi/data-types'
 import type { Action, Estimate, LiFiStep, StepTool, Token } from '@lifi/types'
-import { ChainId, CoinKey } from '@lifi/types'
+import { ChainId, CoinKey, SVMPriorityFeeLevel } from '@lifi/types'
 import { describe, expect, expectTypeOf, it, vi } from 'vitest'
+import { createClient } from '../client/createClient.js'
 import type { LiFiStepRequest } from '../types/actions.js'
 import * as request from '../utils/request.js'
 import { client, setupTestServer } from './actions.unit.handlers.js'
@@ -136,6 +137,47 @@ describe('getStepTransaction', () => {
           expect(mockedFetch).toHaveBeenCalledTimes(1)
         })
       })
+    })
+  })
+
+  describe('with a Solana step', () => {
+    const getSolanaStep = (): LiFiStep =>
+      getStep({ action: getAction({ fromChainId: ChainId.SOL }) })
+
+    const requestedUrl = (): string => mockedFetch.mock.calls[0][1]
+
+    it.each([
+      SVMPriorityFeeLevel.NORMAL,
+      SVMPriorityFeeLevel.FAST,
+      SVMPriorityFeeLevel.ULTRA,
+    ])('forwards svmPriorityFeeLevel=%s from routeOptions as a query param', async (svmPriorityFeeLevel) => {
+      const solanaClient = createClient({
+        integrator: 'lifi-sdk',
+        routeOptions: { svmPriorityFeeLevel },
+      })
+
+      await getStepTransaction(solanaClient, getSolanaStep())
+
+      expect(requestedUrl()).toContain(
+        `/advanced/stepTransaction?svmPriorityFeeLevel=${svmPriorityFeeLevel}`
+      )
+    })
+
+    it('omits svmPriorityFeeLevel when not configured', async () => {
+      await getStepTransaction(client, getSolanaStep())
+
+      expect(requestedUrl()).not.toContain('svmPriorityFeeLevel')
+    })
+
+    it('omits svmPriorityFeeLevel for non-Solana steps', async () => {
+      const solanaClient = createClient({
+        integrator: 'lifi-sdk',
+        routeOptions: { svmPriorityFeeLevel: SVMPriorityFeeLevel.FAST },
+      })
+
+      await getStepTransaction(solanaClient, getStep({}))
+
+      expect(requestedUrl()).not.toContain('svmPriorityFeeLevel')
     })
   })
 


### PR DESCRIPTION
## Which Linear task is linked to this PR?

[JUMEMB-11](https://linear.app/lifi-linear/issue/JUMEMB-11/wire-svmpriorityfeelevel-through-lifisdk-and-expose-it-in-the-widget)

## Why was it implemented this way?

`@lifi/types` already ships `svmPriorityFeeLevel` on `RouteOptions`, so only the forwarding was missing: the value is now appended as a query param in the existing SOL-only branch of `getStepTransaction`, next to `jitoBundle`/`svmSponsor`. Unit tests cover all three tiers, omission, and non-Solana steps.

## Visual showcase (Screenshots or Videos)

n/a

## Checklist before requesting a review
- [x] I have performed a self-review and testing of my code.
- [x] This pull request is focused and addresses a single problem.
- [ ] If this PR modifies the SDK API or adds new features that require documentation, I have updated the documentation in the [public-docs](https://github.com/lifinance/public-docs) repository.