### PR TITLE
chore: trim derivable content from CLAUDE.md, move release detail to a skill

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -1,0 +1,70 @@
+---
+name: release
+description: >-
+  How this monorepo actually publishes: the stable-vs-beta pre-mode toggle, the
+  per-PR `release-preview` label that cuts a throwaway npm build, the
+  `changeset:prepublish` transform that `changeset publish` will NOT run for you,
+  and the Linear release anchor. Use this whenever the user asks about releasing,
+  publishing, cutting a version, dist-tags, `latest`/`beta`/`preview`, entering or
+  exiting pre-mode, sharing an unmerged build with another team, or is debugging
+  the `publish.yaml` pipeline. NOT for authoring changesets or picking a bump —
+  that's the `changeset` skill.
+---
+
+# Releasing
+
+Releases use **Changesets** (independent versioning). Lerna and standard-version are gone.
+The pipeline lives in `.github/workflows/publish.yaml` and runs on push to `main`; read it
+for the current job graph rather than trusting a copy here.
+
+For *authoring* a changeset and choosing the bump level, use the **`changeset` skill** —
+this skill starts where that one ends.
+
+## Versioning: stable 4.x line (pre-mode exited)
+
+- The repo has **exited** Changesets pre-mode and cut **stable `4.0.0`** (now the npm
+  `latest` dist-tag). There is no `.changeset/pre.json`, so normal `changeset version` runs
+  produce stable semver bumps — no beta suffix, no dist-tag regression to guard against.
+- To start a **new beta cycle**, re-enter pre-mode with `changeset pre enter beta` (recreates
+  `.changeset/pre.json`); `changeset pre exit` ends it before cutting the next stable. Both
+  move the npm dist-tags, so don't toggle pre-mode casually.
+
+## Preview releases (per-PR, opt-in)
+
+To share an unmerged PR build with other teams or external integrators, add the
+**`release-preview`** label to the PR. The `preview` job in `publish.yaml` publishes a
+throwaway `0.0.0-preview-<sha>` build of the changed packages to npm under the
+**`preview`** dist-tag and comments the exact install command on the PR. The label is
+removed after a successful publish (one-shot — re-add it to cut another preview).
+
+- Install the **exact** version it prints (e.g. `npm i @lifi/sdk@0.0.0-preview-<sha>`);
+  `@preview` moves with the newest preview across PRs. `0.0.0` can never become `latest`/`beta`.
+  The `<sha>` is the PR head's short commit hash, so the version traces to the exact source.
+- `--snapshot` is disallowed while in pre mode. The repo is on the **stable line** (no
+  `.changeset/pre.json`), so snapshotting works directly. As a safeguard the preview action
+  still runs `changeset pre exit` **only if** a `pre.json` is present, in the **throwaway CI
+  checkout only** (never committed or pushed) — so a future beta cycle won't break previews.
+- Guardrails: applying a label requires Triage+ on the repo, so external people / fork-PR
+  authors can't trigger it; the same-repo guard means the published code was pushed by
+  someone with Write access (forks excluded); and the job is isolated (no Linear secrets).
+  This is GitHub's native label-permission gate — no in-workflow role check.
+
+## The publish transform runs from `changeset:prepublish`, not from publish
+
+**Critical:** `changeset publish` does flat per-package `npm publish` and does **not** run
+`build:prerelease`, so the transform must run in `changeset:prepublish` (which is why
+`changeset:publish` chains the two). Per package:
+
+- `build` writes the dual `dist/{cjs,esm}/package.json` proxy files.
+- `build:prerelease` runs `scripts/prerelease.js` → `formatPackageJson.js#formatPackageFile()`,
+  which strips `scripts`/`devDependencies`/`workspaces`/`nyc` from the **published**
+  `package.json` in place (writing a `package.json.tmp` backup), then copies `README.md`.
+  Restore (`postrelease.js`) is intentionally **not** run in CI.
+- `scripts/version.js` inlines package name/version into `src/version.ts` at build time.
+
+## Linear anchor coverage policy = SKIP
+
+- The only anchor is `@lifi/sdk` → Linear release name "SDK", secret
+  `LINEAR_RELEASE_ACCESS_KEY`. A **provider-only** release cycle won't bump `@lifi/sdk`,
+  so the "SDK" Linear release is **skipped** for that cycle. There is no fallback anchor —
+  provider-only releases are deliberately not reflected in Linear.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,30 +4,13 @@
 TypeScript monorepo (pnpm workspaces) with 6 packages under `packages/`. `@lifi/sdk`
 is the hub; each provider depends on it via `workspace:*` as a **regular** dependency
 (not peer), which resolves to the exact pinned version in published tarballs.
-- `@lifi/sdk` — core SDK (no deps on other workspace packages)
-- `@lifi/sdk-provider-ethereum` — EVM provider (depends on sdk, uses viem)
-- `@lifi/sdk-provider-solana` — Solana provider (depends on sdk, uses @solana/kit)
-- `@lifi/sdk-provider-bitcoin` — Bitcoin provider (depends on sdk, uses bitcoinjs-lib)
-- `@lifi/sdk-provider-sui` — Sui provider (depends on sdk, ESM-only, no CJS)
-- `@lifi/sdk-provider-tron` — Tron provider (depends on sdk, uses tronweb)
 
 ## Build
-- `pnpm build` — runs tsdown in all packages in parallel (no dependency ordering needed)
-- `pnpm check` — biome lint/format
-- `pnpm check:types` — tsc --noEmit (separate from build)
-- Build outputs: `dist/esm/` (ESM + .d.ts), `dist/cjs/` (CJS only, not for sui)
-- tsdown configs in each package root (`tsdown.config.ts`)
+- `pnpm build` runs all packages in parallel — no dependency ordering needed
 - `isolatedDeclarations: true` — all exports need explicit return type annotations
 
-## Testing & CI
-- `pnpm test:unit` — vitest unit tests
-- `pnpm pre-commit` — runs check + check:types + circular-deps + knip (via husky)
-- `pnpm pre-push` — runs unit tests (via husky)
-
 ## Code Style
-- Biome for formatting and linting (`pnpm check:write` to auto-fix)
 - No default exports in library code
-- Import types with `import type` syntax
 
 ## Known Issues
 - `sdk-provider-ethereum/src/utils/abi.ts` — parseAbi results typed as `Abi` (broader than inferred); downstream code uses `as` casts for readContract results
@@ -48,63 +31,11 @@ standard-version are gone.
   default — re-releases every provider on *any* `@lifi/sdk` bump, including a patch, so their
   `workspace:*` pins stay current.)
 
-### Versioning: stable 4.x line (pre-mode exited)
-- The repo has **exited** Changesets pre-mode and cut **stable `4.0.0`** (now the npm
-  `latest` dist-tag). There is no `.changeset/pre.json`, so normal `changeset version` runs
-  produce stable semver bumps — no beta suffix, no dist-tag regression to guard against.
-- To start a **new beta cycle**, re-enter pre-mode with `changeset pre enter beta` (recreates
-  `.changeset/pre.json`); `changeset pre exit` ends it before cutting the next stable. Both
-  move the npm dist-tags, so don't toggle pre-mode casually.
+### Cutting a release
 
-### Pipeline (`.github/workflows/publish.yaml`, push to `main`)
-1. `verify` — reuses `tests.yaml` (build + test).
-2. `changesets` — opens/refreshes the "chore: version packages" PR
-   (`pnpm changeset:version`). Merging it lands the version bumps.
-3. `release` — runs only when `hasChangesets == 'false'`; `pnpm changeset:publish`
-   + `createGithubReleases: true`. Holds `id-token: write` for npm provenance.
-4. `linear-release` — single **static** anchor: only when `@lifi/sdk` is in
-   `release.outputs.publishedPackages` does it sync the "SDK" Linear release.
-
-### Preview releases (per-PR, opt-in)
-
-To share an unmerged PR build with other teams or external integrators, add the
-**`release-preview`** label to the PR. The `preview` job in `publish.yaml` publishes a
-throwaway `0.0.0-preview-<sha>` build of the changed packages to npm under the
-**`preview`** dist-tag and comments the exact install command on the PR. The label is
-removed after a successful publish (one-shot — re-add it to cut another preview).
-
-- Install the **exact** version it prints (e.g. `npm i @lifi/sdk@0.0.0-preview-<sha>`);
-  `@preview` moves with the newest preview across PRs. `0.0.0` can never become `latest`/`beta`.
-  The `<sha>` is the PR head's short commit hash, so the version traces to the exact source.
-- `--snapshot` is disallowed while in pre mode. The repo is on the **stable line** (no
-  `.changeset/pre.json`), so snapshotting works directly. As a safeguard the preview action
-  still runs `changeset pre exit` **only if** a `pre.json` is present, in the **throwaway CI
-  checkout only** (never committed or pushed) — so a future beta cycle won't break previews.
-- Guardrails: applying a label requires Triage+ on the repo, so external people / fork-PR
-  authors can't trigger it; the same-repo guard means the published code was pushed by
-  someone with Write access (forks excluded); and the job is isolated (no Linear secrets).
-  This is GitHub's native label-permission gate — no in-workflow role check.
-
-### Root scripts
-- `changeset:version` — `changeset version` + `pnpm install --lockfile-only` + `pnpm check:write`.
-- `changeset:prepublish` — `pnpm build` then per-package `build:prerelease`
-  (the publish transform). **Critical:** `changeset publish` does flat per-package
-  `npm publish` and does **not** run `build:prerelease`, so the transform must run here.
-- `changeset:publish` — `pnpm changeset:prepublish && changeset publish`.
-
-### Publish transform (per package)
-- `build` writes the dual `dist/{cjs,esm}/package.json` proxy files.
-- `build:prerelease` runs `scripts/prerelease.js` → `formatPackageJson.js#formatPackageFile()`,
-  which strips `scripts`/`devDependencies`/`workspaces`/`nyc` from the **published**
-  `package.json` in place (writing a `package.json.tmp` backup), then copies `README.md`.
-  Restore (`postrelease.js`) is intentionally **not** run in CI.
-- `scripts/version.js` inlines package name/version into `src/version.ts` at build time.
-
-### Linear anchor coverage policy = SKIP
-- The only anchor is `@lifi/sdk` → Linear release name "SDK", secret
-  `LINEAR_RELEASE_ACCESS_KEY`. A **provider-only** release cycle won't bump `@lifi/sdk`,
-  so the "SDK" Linear release is **skipped** for that cycle. There is no fallback anchor —
-  provider-only releases are deliberately not reflected in Linear.
+Pre-mode/dist-tags, per-PR `release-preview` builds, the `changeset:prepublish` transform,
+and the Linear anchor policy live in the **`release` skill**
+(`.claude/skills/release/SKILL.md`). Read it before touching the publish path.
 
 ### External pinned deps — bump MANUALLY (out of Changesets scope)
 - `@lifi/types` (17.x, in `@lifi/sdk` deps) and `@lifi/data-types` (devDep) are external


### PR DESCRIPTION
## TL;DR

`CLAUDE.md` shrinks from 7,454 to 2,754 chars (~1.2k fewer tokens loaded into every
Claude Code session in this repo). Nothing is lost: the derivable parts are dropped
because a session can read them off disk, and the release-pipeline detail moves to a
lazily-loaded `release` skill.

No changeset — docs/tooling only, no publishable source touched.

## DESCRIPTION

**Cut from `CLAUDE.md` (reconstructible from the repo itself):**

| Cut | Where it already lives |
|---|---|
| The 6-package list | `ls packages/` + each `package.json` |
| `pnpm build` / `check` / `check:types`, `dist/` layout, tsdown config locations | root `package.json` scripts, the tsdown configs |
| Whole `## Testing & CI` section | `test:unit` / `pre-commit` / `pre-push` scripts, wired via `.husky/` |
| "Biome for formatting and linting" | `biome.json` |
| "Import types with `import type`" | `biome explain useImportType` → in Biome's **recommended** preset, which `biome.json` enables, so it's enforced mechanically |
| `### Pipeline` numbered job list | `.github/workflows/publish.yaml` |
| `changeset:version — …` description | root `package.json` |

**Moved to `.claude/skills/release/SKILL.md`** (loads on demand; only its description
line stays in context): stable-vs-beta pre-mode and dist-tags, per-PR `release-preview`
builds, the `changeset publish` / `build:prerelease` transform caveat, the publish
transform details, and the Linear anchor coverage policy. It defers to the existing
`changeset` skill for authoring and bump rules so the two can't drift apart.

**Deliberately kept in `CLAUDE.md`** — none of this is derivable from the code:

- Why providers depend on `@lifi/sdk` as a *regular* (not peer) dependency
- `pnpm build` runs in parallel with no dependency ordering needed
- `isolatedDeclarations: true` → all exports need explicit return types
- No default exports in library code (`noDefaultExport` is *not* in Biome's recommended set)
- Known Issues, the per-PR changeset rule, the manual `@lifi/types` pin rule, and all
  `## pnpm config` gotchas

## STEPS TO TEST

1. `git diff origin/main -- CLAUDE.md` — check each removed block against the file it
   points to above.
2. Ask a fresh session a release question ("how do preview releases work here?") and
   confirm it reaches for the `release` skill.

## EXPECTED RESULTS

Every cut line is recoverable from the source of truth it duplicated; release guidance
is still reachable, just not resident. No build, lint, type, or test behavior changes.

## CHECKLIST

- [x] Performed a self-review of my code
- [x] Added comments to the code for better readability — n/a, docs-only change
- [ ] Added tests that cover the new functionality — n/a, no code changed
- [x] Made sure that existing tests are still passing — full `pnpm pre-commit`
      (check + check:types + circular-deps + knip) passed locally
