### PR TITLE
fix(ethereum): keep the Permit2 spender for relayed steps

### DIFF
--- a/.changeset/permit2-smart-account-signer.md
+++ b/.changeset/permit2-smart-account-signer.md
@@ -4,4 +4,6 @@
 
 Fix `getAccountCode` treating a code-less account as a failed RPC lookup (viem's `getCode` returns `undefined` for both), suppressing native EIP-2612 permits for every plain EOA. Permit-supporting tokens now route through `callDiamondWithEIP2612Signature` rather than `callDiamondWithPermit2`, skipping the `approve(permit2)`.
 
-Fix Permit2 reverting for EIP-7702 delegated accounts. Permit2 verifies code-bearing signers via EIP-1271, where acceptance is implementation-specific, so the signer is now probed with a read-only `isValidSignature` call — only accounts that reject it fall back to approve + execute.
+Fix Permit2 reverting for EIP-7702 delegated accounts. Permit2 verifies code-bearing signers via EIP-1271, where acceptance is implementation-specific, so the signer is now probed with a read-only `isValidSignature` call — only accounts that reject it fall back to approve + execute. The probe gates the standard transaction flow only — relayer-settled steps keep the spender they already used.
+
+`isSafeWallet` no longer queries the Safe Transaction Service for an address with no on-chain code. Its code-less short-circuit was unreachable while `getAccountCode` conflated "no code" with "RPC failed", so an undeployed or counterfactual Safe now resolves as a non-Safe wallet instead of falling through to the API. This surfaces through `resolveTransactionHash`, which returns such a value as a plain transaction hash rather than tracking it as a Safe signature.

--- a/packages/sdk-provider-ethereum/src/actions/checkPermitSupport.ts
+++ b/packages/sdk-provider-ethereum/src/actions/checkPermitSupport.ts
@@ -18,10 +18,8 @@ type PermitSupport = {
  * Checks what permit types are *usable* for a token on a specific chain.
  * Checks in order:
  * 1. Native permit (EIP-2612) support
- * 2. Permit2 — deployed on the chain, signable by the owner (an account with
- *    on-chain code may be rejected by Permit2's EIP-1271 path, so any
- *    allowance it holds may be unusable — see `canAccountUsePermit2`), and
- *    allowance sufficient
+ * 2. Permit2 — deployed on the chain, signable by the owner (see
+ *    `canAccountUsePermit2`), and allowance sufficient
  *
  * @param client - The SDK client
  * @param chain - The chain to check permit support on
@@ -69,10 +67,8 @@ export const checkPermitSupport = async (
   )
 
   let permit2Allowance: bigint | undefined
-  // Check Permit2 allowance if available on chain and the owner can actually
-  // sign for it — code-bearing accounts may be rejected by Permit2's EIP-1271
-  // path, so an existing allowance may not be usable. See
-  // `canAccountUsePermit2`.
+  // Only read the allowance if the owner can sign for it: Permit2 may reject a
+  // code-bearing account via EIP-1271, making any allowance unusable.
   if (
     chain.permit2 &&
     (await canAccountUsePermit2(client, {

--- a/packages/sdk-provider-ethereum/src/actions/checkPermitSupport.ts
+++ b/packages/sdk-provider-ethereum/src/actions/checkPermitSupport.ts
@@ -19,8 +19,9 @@ type PermitSupport = {
  * Checks in order:
  * 1. Native permit (EIP-2612) support
  * 2. Permit2 — deployed on the chain, signable by the owner (an account with
- *    on-chain code is rejected by Permit2's EIP-1271 path, so any allowance it
- *    holds is unusable — see `canAccountUsePermit2`), and allowance sufficient
+ *    on-chain code may be rejected by Permit2's EIP-1271 path, so any
+ *    allowance it holds may be unusable — see `canAccountUsePermit2`), and
+ *    allowance sufficient
  *
  * @param client - The SDK client
  * @param chain - The chain to check permit support on
@@ -69,8 +70,9 @@ export const checkPermitSupport = async (
 
   let permit2Allowance: bigint | undefined
   // Check Permit2 allowance if available on chain and the owner can actually
-  // sign for it — code-bearing accounts are rejected by Permit2's EIP-1271
-  // path, so an existing allowance is not usable. See `canAccountUsePermit2`.
+  // sign for it — code-bearing accounts may be rejected by Permit2's EIP-1271
+  // path, so an existing allowance may not be usable. See
+  // `canAccountUsePermit2`.
   if (
     chain.permit2 &&
     (await canAccountUsePermit2(client, {

--- a/packages/sdk-provider-ethereum/src/actions/checkPermitSupport.unit.spec.ts
+++ b/packages/sdk-provider-ethereum/src/actions/checkPermitSupport.unit.spec.ts
@@ -52,9 +52,9 @@ beforeEach(() => {
 describe('checkPermitSupport — Permit2 signer gate', () => {
   it('reports no usable Permit2 allowance for a code-bearing owner, and skips the allowance read', async () => {
     // A 7702-delegated EOA may well hold a large Permit2 allowance from an
-    // earlier plain-EOA session. It is unusable — Permit2 would verify via
-    // EIP-1271 and reject — so reporting it as sufficient would tell callers
-    // to skip an approval they actually need.
+    // earlier plain-EOA session. It may not be usable — Permit2 verifies via
+    // EIP-1271, which may reject — so reporting it as sufficient would tell
+    // callers to skip an approval they actually need.
     vi.mocked(canAccountUsePermit2).mockResolvedValue(false)
 
     await expect(subject()).resolves.toEqual({

--- a/packages/sdk-provider-ethereum/src/actions/checkPermitSupport.unit.spec.ts
+++ b/packages/sdk-provider-ethereum/src/actions/checkPermitSupport.unit.spec.ts
@@ -51,10 +51,8 @@ beforeEach(() => {
 
 describe('checkPermitSupport — Permit2 signer gate', () => {
   it('reports no usable Permit2 allowance for a code-bearing owner, and skips the allowance read', async () => {
-    // A 7702-delegated EOA may well hold a large Permit2 allowance from an
-    // earlier plain-EOA session. It may not be usable — Permit2 verifies via
-    // EIP-1271, which may reject — so reporting it as sufficient would tell
-    // callers to skip an approval they actually need.
+    // A 7702-delegated EOA can still hold a large allowance from its plain-EOA
+    // days. Reporting it as sufficient would skip an approval that is needed.
     vi.mocked(canAccountUsePermit2).mockResolvedValue(false)
 
     await expect(subject()).resolves.toEqual({

--- a/packages/sdk-provider-ethereum/src/core/tasks/helpers/resolvePermit2Support.ts
+++ b/packages/sdk-provider-ethereum/src/core/tasks/helpers/resolvePermit2Support.ts
@@ -29,48 +29,22 @@ const isPermit2SupportedForStep = (
 /**
  * Whether this step should use the Permit2 signature flow.
  *
- * On top of the step/chain checks, the `standard` strategy also verifies that
- * the *signer* can actually produce a Permit2-verifiable signature — see
- * {@link canAccountUsePermit2}. Accounts with on-chain code send Permit2 down
- * its EIP-1271 path, where whether our plain ECDSA signature is accepted
- * depends on the account implementation, so it is probed rather than assumed.
- * Accounts that reject it fall back to approve + execute.
+ * Beyond the step/chain checks, the `standard` strategy also probes the
+ * *signer*: code-bearing accounts send Permit2 down its EIP-1271 path, where
+ * acceptance is implementation-specific — see {@link canAccountUsePermit2}.
+ * Accounts that fail it fall back to approve + execute.
  *
- * Only the `standard` strategy consults the signer probe. `signPermit2Message`
- * has a single call site — `EthereumStandardSignAndExecuteTask` — so that is the
- * only flow where the SDK produces the Permit2 signature itself. A relayed step
- * is settled by the relayer pulling through Permit2 with typed data the API
- * supplied, and it has no approve + execute fallback, so a signer verdict has
- * nothing to steer and must never move the allowance spender away from
- * `fromChain.permit2`.
+ * Only `standard` consults the probe. `signPermit2Message` has one call site,
+ * `EthereumStandardSignAndExecuteTask`, so that is the only flow where the SDK
+ * produces the Permit2 signature itself. A relayed step has no approve +
+ * execute fallback, so a verdict cannot rescue a failing account and would
+ * break a working one — it must never move the spender off `fromChain.permit2`.
  *
- * This does not make relayed steps immune to the underlying problem.
- * `EthereumRelayedSignAndExecuteTask` signs the step's typed data and the
- * relayer submits that signature to Permit2, which branches on `code.length`
- * the same way, so an account that genuinely fails the probe also fails the
- * relayer's pull. Moving the spender cannot rescue that account, and it breaks
- * every account that would have succeeded — which is why the verdict is not
- * consulted here.
- *
- * Named `resolve…` rather than `is…` because it is not a pure predicate: the
- * signer verdict is memoized onto `context.permit2SignerSupported`.
- * `TaskPipeline` threads one context object through the whole run, so every
- * task in a single execution agrees on the answer and only one `eth_getCode`
- * is issued — without that, a wallet gaining or losing its 7702 delegation
- * mid-swap could have the allowance tasks approve Permit2 while the
- * sign-and-execute task routes to the diamond, which then has no allowance.
- *
- * For the same reason a `false` stays sticky, including one caused by a failed
- * code lookup: retrying it later in the pipeline is what makes the two sides
- * disagree. `EthereumCheckAllowanceTask` reading `false` approves
- * `step.estimate.approvalAddress` — or finds an existing allowance there and
- * lets `EthereumSetAllowanceTask` skip entirely — and a later retry that
- * flipped to `true` would then route the sign task through Permit2 with no
- * Permit2 allowance, turning a needless approval into a revert.
- *
- * Resolved lazily, after the cheap checks and the strategy guard, so steps that
- * never consult the probe (native token, batched, relayed, `skipPermit`, …)
- * don't pay for the RPC at all.
+ * The verdict is memoized on `context.permit2SignerSupported`, and a `false`
+ * stays sticky, a failed lookup included. `TaskPipeline` threads one context
+ * through every task, so a mid-run flip would let the allowance tasks approve
+ * one spender while the sign task routes to the other — turning a needless
+ * approval into a revert.
  */
 export const resolvePermit2Support = async (
   context: EthereumStepExecutorContext,
@@ -80,8 +54,7 @@ export const resolvePermit2Support = async (
     return false
   }
 
-  // The signer probe gates only the flow where the SDK itself produces the
-  // Permit2 signature. `batched` was already excluded above.
+  // Only `standard` consults the probe; `batched` is excluded above.
   if (strategy !== 'standard') {
     return true
   }
@@ -93,8 +66,7 @@ export const resolvePermit2Support = async (
     return false
   }
 
-  // Safe to cache the promise: `canAccountUsePermit2` resolves `false` on RPC
-  // failure rather than rejecting, so this can never memoize a rejection.
+  // Caching the promise is safe: `canAccountUsePermit2` never rejects.
   context.permit2SignerSupported ??= canAccountUsePermit2(client, {
     chainId: fromChain.id,
     address,

--- a/packages/sdk-provider-ethereum/src/core/tasks/helpers/resolvePermit2Support.ts
+++ b/packages/sdk-provider-ethereum/src/core/tasks/helpers/resolvePermit2Support.ts
@@ -36,6 +36,14 @@ const isPermit2SupportedForStep = (
  * implementation, so it is probed rather than assumed. Accounts that reject it
  * fall back to approve + execute.
  *
+ * Only the `standard` strategy consults the signer probe. `signPermit2Message`
+ * has a single call site — `EthereumStandardSignAndExecuteTask` — so that is the
+ * only flow where the SDK produces the Permit2 signature itself. A relayed step
+ * is settled by the relayer pulling through Permit2 with typed data the API
+ * supplied, and it has no approve + execute fallback, so a signer verdict has
+ * nothing to steer and must never move the allowance spender away from
+ * `fromChain.permit2`.
+ *
  * Named `resolve…` rather than `is…` because it is not a pure predicate: the
  * signer verdict is memoized onto `context.permit2SignerSupported`.
  * `TaskPipeline` threads one context object through the whole run, so every
@@ -43,6 +51,14 @@ const isPermit2SupportedForStep = (
  * is issued — without that, a wallet gaining or losing its 7702 delegation
  * mid-swap could have the allowance tasks approve Permit2 while the
  * sign-and-execute task routes to the diamond, which then has no allowance.
+ *
+ * For the same reason a `false` stays sticky, including one caused by a failed
+ * code lookup: retrying it later in the pipeline is what makes the two sides
+ * disagree. `EthereumCheckAllowanceTask` reading `false` approves
+ * `step.estimate.approvalAddress` — or finds an existing allowance there and
+ * lets `EthereumSetAllowanceTask` skip entirely — and a later retry that
+ * flipped to `true` would then route the sign task through Permit2 with no
+ * Permit2 allowance, turning a needless approval into a revert.
  *
  * Resolved lazily, after the cheap checks, so steps that can never use Permit2
  * (native token, batched, `skipPermit`, …) don't pay for the RPC at all.
@@ -53,6 +69,12 @@ export const resolvePermit2Support = async (
 ): Promise<boolean> => {
   if (!isPermit2SupportedForStep(context, strategy)) {
     return false
+  }
+
+  // The signer probe gates only the flow where the SDK itself produces the
+  // Permit2 signature. `batched` was already excluded above.
+  if (strategy !== 'standard') {
+    return true
   }
 
   const { client, step, fromChain, ethereumClient } = context

--- a/packages/sdk-provider-ethereum/src/core/tasks/helpers/resolvePermit2Support.ts
+++ b/packages/sdk-provider-ethereum/src/core/tasks/helpers/resolvePermit2Support.ts
@@ -29,12 +29,12 @@ const isPermit2SupportedForStep = (
 /**
  * Whether this step should use the Permit2 signature flow.
  *
- * On top of the step/chain checks this verifies that the *signer* can actually
- * produce a Permit2-verifiable signature — see {@link canAccountUsePermit2}.
- * Accounts with on-chain code send Permit2 down its EIP-1271 path, where
- * whether our plain ECDSA signature is accepted depends on the account
- * implementation, so it is probed rather than assumed. Accounts that reject it
- * fall back to approve + execute.
+ * On top of the step/chain checks, the `standard` strategy also verifies that
+ * the *signer* can actually produce a Permit2-verifiable signature — see
+ * {@link canAccountUsePermit2}. Accounts with on-chain code send Permit2 down
+ * its EIP-1271 path, where whether our plain ECDSA signature is accepted
+ * depends on the account implementation, so it is probed rather than assumed.
+ * Accounts that reject it fall back to approve + execute.
  *
  * Only the `standard` strategy consults the signer probe. `signPermit2Message`
  * has a single call site — `EthereumStandardSignAndExecuteTask` — so that is the
@@ -43,6 +43,14 @@ const isPermit2SupportedForStep = (
  * supplied, and it has no approve + execute fallback, so a signer verdict has
  * nothing to steer and must never move the allowance spender away from
  * `fromChain.permit2`.
+ *
+ * This does not make relayed steps immune to the underlying problem.
+ * `EthereumRelayedSignAndExecuteTask` signs the step's typed data and the
+ * relayer submits that signature to Permit2, which branches on `code.length`
+ * the same way, so an account that genuinely fails the probe also fails the
+ * relayer's pull. Moving the spender cannot rescue that account, and it breaks
+ * every account that would have succeeded — which is why the verdict is not
+ * consulted here.
  *
  * Named `resolve…` rather than `is…` because it is not a pure predicate: the
  * signer verdict is memoized onto `context.permit2SignerSupported`.
@@ -60,8 +68,9 @@ const isPermit2SupportedForStep = (
  * flipped to `true` would then route the sign task through Permit2 with no
  * Permit2 allowance, turning a needless approval into a revert.
  *
- * Resolved lazily, after the cheap checks, so steps that can never use Permit2
- * (native token, batched, `skipPermit`, …) don't pay for the RPC at all.
+ * Resolved lazily, after the cheap checks and the strategy guard, so steps that
+ * never consult the probe (native token, batched, relayed, `skipPermit`, …)
+ * don't pay for the RPC at all.
  */
 export const resolvePermit2Support = async (
   context: EthereumStepExecutorContext,

--- a/packages/sdk-provider-ethereum/src/core/tasks/helpers/resolvePermit2Support.unit.spec.ts
+++ b/packages/sdk-provider-ethereum/src/core/tasks/helpers/resolvePermit2Support.unit.spec.ts
@@ -52,8 +52,8 @@ describe('resolvePermit2Support — signer gate (JUMEMB-32)', () => {
 
   it('is NOT supported when the signer has on-chain code', async () => {
     // The whole point: a 7702-delegated EOA passes every step/chain check but
-    // its ECDSA signature is rejected by Permit2's EIP-1271 path, so the tx
-    // reverts before reaching the diamond. Must fall back to approve+execute.
+    // may be rejected by Permit2's EIP-1271 path, so the probe asks rather than
+    // assumes. A `false` verdict must fall back to approve+execute.
     vi.mocked(canAccountUsePermit2).mockResolvedValue(false)
     expect(await run(buildContext())).toBe(false)
   })

--- a/packages/sdk-provider-ethereum/src/core/tasks/helpers/resolvePermit2Support.unit.spec.ts
+++ b/packages/sdk-provider-ethereum/src/core/tasks/helpers/resolvePermit2Support.unit.spec.ts
@@ -51,9 +51,8 @@ describe('resolvePermit2Support — signer gate (JUMEMB-32)', () => {
   })
 
   it('is NOT supported when the signer has on-chain code', async () => {
-    // The whole point: a 7702-delegated EOA passes every step/chain check but
-    // may be rejected by Permit2's EIP-1271 path, so the probe asks rather than
-    // assumes. A `false` verdict must fall back to approve+execute.
+    // A 7702-delegated EOA passes every step/chain check, but Permit2 may still
+    // reject it via EIP-1271 — so a `false` verdict must approve + execute.
     vi.mocked(canAccountUsePermit2).mockResolvedValue(false)
     expect(await run(buildContext())).toBe(false)
   })
@@ -192,13 +191,8 @@ describe('resolvePermit2Support — step/chain gate short-circuits before the RP
 
 describe('resolvePermit2Support — the probe gates the standard flow only', () => {
   it('keeps a relayed step on Permit2 even when the signer would fail the probe', async () => {
-    // The relayer pulls the user's tokens through Permit2 using typed data the
-    // API supplied. `signPermit2Message` has one call site and it is in the
-    // standard sign task, so the SDK never produces that signature here — and a
-    // relayed step has no approve + execute fallback. A probe verdict therefore
-    // has nothing to steer, and letting it move the spender to
-    // `approvalAddress` leaves the relayer unable to pull: the transfer fails
-    // for missing allowance and the user paid for a useless approval.
+    // Moving the spender to `approvalAddress` leaves the relayer unable to pull
+    // through Permit2: the transfer fails and the approval was wasted.
     vi.mocked(canAccountUsePermit2).mockResolvedValue(false)
 
     expect(await run(buildContext(), 'relayed')).toBe(true)
@@ -211,8 +205,8 @@ describe('resolvePermit2Support — the probe gates the standard flow only', () 
   })
 
   it('leaves the memoized verdict unset for a relayed step', async () => {
-    // The guard returns before the memo slot is touched, so a later standard
-    // step in the same execution still resolves the signer for itself.
+    // The guard returns before the memo write, so a later standard step in the
+    // same execution still resolves the signer for itself.
     const context = buildContext()
 
     await run(context, 'relayed')

--- a/packages/sdk-provider-ethereum/src/core/tasks/helpers/resolvePermit2Support.unit.spec.ts
+++ b/packages/sdk-provider-ethereum/src/core/tasks/helpers/resolvePermit2Support.unit.spec.ts
@@ -189,3 +189,42 @@ describe('resolvePermit2Support — step/chain gate short-circuits before the RP
     expect(canAccountUsePermit2).not.toHaveBeenCalled()
   })
 })
+
+describe('resolvePermit2Support — the probe gates the standard flow only', () => {
+  it('keeps a relayed step on Permit2 even when the signer would fail the probe', async () => {
+    // The relayer pulls the user's tokens through Permit2 using typed data the
+    // API supplied. `signPermit2Message` has one call site and it is in the
+    // standard sign task, so the SDK never produces that signature here — and a
+    // relayed step has no approve + execute fallback. A probe verdict therefore
+    // has nothing to steer, and letting it move the spender to
+    // `approvalAddress` leaves the relayer unable to pull: the transfer fails
+    // for missing allowance and the user paid for a useless approval.
+    vi.mocked(canAccountUsePermit2).mockResolvedValue(false)
+
+    expect(await run(buildContext(), 'relayed')).toBe(true)
+  })
+
+  it('issues no signer RPC for a relayed step', async () => {
+    await run(buildContext(), 'relayed')
+
+    expect(canAccountUsePermit2).not.toHaveBeenCalled()
+  })
+
+  it('leaves the memoized verdict unset for a relayed step', async () => {
+    // The guard returns before the memo slot is touched, so a later standard
+    // step in the same execution still resolves the signer for itself.
+    const context = buildContext()
+
+    await run(context, 'relayed')
+
+    expect(context.permit2SignerSupported).toBeUndefined()
+  })
+
+  it('still applies the step/chain checks to a relayed step', async () => {
+    // Regression guard: the strategy guard must not become a blanket `true`. A
+    // native from-token can never use Permit2, whoever signs.
+    expect(
+      await run(buildContext({ isFromNativeToken: true }), 'relayed')
+    ).toBe(false)
+  })
+})

--- a/packages/sdk-provider-ethereum/src/permits/canAccountUsePermit2.ts
+++ b/packages/sdk-provider-ethereum/src/permits/canAccountUsePermit2.ts
@@ -37,18 +37,11 @@ const PROBE_SIGNATURE =
  * - **Reverts** → it rejected the envelope before recovery and can't validate
  *   anything we produce (Alchemy's ERC-6900 `SemiModularAccount7702`).
  *
- * Keyed on revert-vs-return, not on revert data: the same ERC-6900 account
- * reverts with `ValidationSignatureSegmentMissing()` for a malformed signature
- * but with no data for a well-formed one. An empty return counts as unusable —
- * it fails Permit2's magic-value comparison too.
- *
- * Accepted limit: an implementation that returns the failure value for *every*
- * signature is indistinguishable from one that would accept ours, so it is
- * classified capable here and still fails on-chain. Return-vs-revert is the only
- * signal available — the probe signature recovers to a third party on purpose,
- * so a correct implementation must return a non-magic value, and comparing
- * against the magic value would reject every wallet this probe exists to
- * accept. Only verifying the real signature after signing closes that gap.
+ * Keyed on revert-vs-return, never on the value returned: the probe signature
+ * recovers to a third party on purpose, so a correct implementation must return
+ * a *non*-magic value, and comparing against the magic value would reject every
+ * wallet this exists to accept. Accepted cost: an implementation that returns
+ * failure for *everything* is classified capable and still fails on-chain.
  */
 const acceptsRawEcdsaSignature = async (
   client: SDKClient,
@@ -58,18 +51,11 @@ const acceptsRawEcdsaSignature = async (
   try {
     const publicClient = await getPublicClient(client, chainId)
     const { data } = await getAction(
-      // Never follow an `OffchainLookup` revert. Following it would send an
-      // outbound request to a URL this contract chose, and would hand back a
-      // return where the account actually reverted — inverting the one signal
-      // read below. viem gates CCIP-Read on the client rather than on the call,
-      // so the probe runs on a copy with it disabled; the shared public client
-      // still needs CCIP for ENS.
-      //
-      // NOTE: this works because `getPublicClient` returns a bare `createClient`
-      // with no `publicActions`, so `getAction` falls through to the `call`
-      // imported here. If that client is ever extended with `publicActions`,
-      // `getAction` would prefer its decorated `client.call`, which closes over
-      // the original client and would silently re-enable CCIP-Read.
+      // CCIP-Read off, or an `OffchainLookup` revert comes back as a return and
+      // inverts the signal read below. viem gates it on the client, not the
+      // call, so clone rather than disable it on the shared ENS-using client.
+      // Relies on `getPublicClient` staying bare: add `publicActions` and
+      // `getAction` prefers a decorated `client.call`, re-enabling CCIP-Read.
       { ...publicClient, ccipRead: false },
       call,
       'call'
@@ -81,9 +67,8 @@ const acceptsRawEcdsaSignature = async (
         args: [PROBE_HASH, PROBE_SIGNATURE],
       }),
     })
-    // A full 32-byte word or nothing (`0x` + 64 hex characters = 66). Permit2
-    // compares the return against its magic value, so anything shorter can
-    // never satisfy it on-chain and would only be a false positive here.
+    // A full 32-byte word (`0x` + 64 chars) or nothing: Permit2 compares against
+    // a magic value, so anything shorter can only be a false positive.
     return !!data && data.length >= 66
   } catch {
     // Revert, or an RPC failure we can't tell apart from one. Either way we
@@ -96,20 +81,15 @@ const acceptsRawEcdsaSignature = async (
  * Whether the account can produce a signature Uniswap Permit2 will accept.
  *
  * Permit2's `SignatureVerification.verify` branches on
- * `claimedSigner.code.length`: no code → `ecrecover`, which every EOA satisfies
- * (and costs no extra RPC here); code → `owner.isValidSignature(...)`, whose
- * outcome depends on the implementation, so {@link acceptsRawEcdsaSignature}
- * tests it rather than guessing. Checking code length alone would exclude
- * EIP-7702 accounts that verify our signatures fine, costing those users a
- * needless approval.
+ * `claimedSigner.code.length`: no code → `ecrecover`, which every EOA satisfies;
+ * code → `owner.isValidSignature(...)`, so {@link acceptsRawEcdsaSignature}
+ * probes it. Checking code length alone would exclude EIP-7702 accounts that
+ * verify our signatures fine, costing those users a needless approval.
  *
- * `false` on RPC failure — the approve + execute fallback always works.
- *
- * Accepted downgrade: an implementation that *reverts* on a signer mismatch
- * (`require(recovered == owner)` 7702 delegates, Sequence contract signatures)
- * fails the probe although it would accept the real signature. Those accounts
- * pay one exact-amount approval per step instead of using Permit2 — a gas cost
- * on a route that works, not a failure.
+ * `false` on RPC failure — approve + execute always works. Same for accounts
+ * that *revert* on a signer mismatch (strict 7702 delegates, Sequence): they
+ * would accept the real signature but fail the probe, and pay one exact-amount
+ * approval per step instead.
  */
 export const canAccountUsePermit2 = async (
   client: SDKClient,

--- a/packages/sdk-provider-ethereum/src/permits/canAccountUsePermit2.ts
+++ b/packages/sdk-provider-ethereum/src/permits/canAccountUsePermit2.ts
@@ -41,6 +41,14 @@ const PROBE_SIGNATURE =
  * reverts with `ValidationSignatureSegmentMissing()` for a malformed signature
  * but with no data for a well-formed one. An empty return counts as unusable —
  * it fails Permit2's magic-value comparison too.
+ *
+ * Accepted limit: an implementation that returns the failure value for *every*
+ * signature is indistinguishable from one that would accept ours, so it is
+ * classified capable here and still fails on-chain. Return-vs-revert is the only
+ * signal available — the probe signature recovers to a third party on purpose,
+ * so a correct implementation must return a non-magic value, and comparing
+ * against the magic value would reject every wallet this probe exists to
+ * accept. Only verifying the real signature after signing closes that gap.
  */
 const acceptsRawEcdsaSignature = async (
   client: SDKClient,
@@ -50,7 +58,19 @@ const acceptsRawEcdsaSignature = async (
   try {
     const publicClient = await getPublicClient(client, chainId)
     const { data } = await getAction(
-      publicClient,
+      // Never follow an `OffchainLookup` revert. Following it would send an
+      // outbound request to a URL this contract chose, and would hand back a
+      // return where the account actually reverted — inverting the one signal
+      // read below. viem gates CCIP-Read on the client rather than on the call,
+      // so the probe runs on a copy with it disabled; the shared public client
+      // still needs CCIP for ENS.
+      //
+      // NOTE: this works because `getPublicClient` returns a bare `createClient`
+      // with no `publicActions`, so `getAction` falls through to the `call`
+      // imported here. If that client is ever extended with `publicActions`,
+      // `getAction` would prefer its decorated `client.call`, which closes over
+      // the original client and would silently re-enable CCIP-Read.
+      { ...publicClient, ccipRead: false },
       call,
       'call'
     )({
@@ -61,8 +81,10 @@ const acceptsRawEcdsaSignature = async (
         args: [PROBE_HASH, PROBE_SIGNATURE],
       }),
     })
-    // At least 4 bytes — enough for a bytes4 the caller could compare.
-    return !!data && data.length >= 10
+    // A full 32-byte word or nothing (`0x` + 64 hex characters = 66). Permit2
+    // compares the return against its magic value, so anything shorter can
+    // never satisfy it on-chain and would only be a false positive here.
+    return !!data && data.length >= 66
   } catch {
     // Revert, or an RPC failure we can't tell apart from one. Either way we
     // must not promise Permit2 will work.
@@ -82,6 +104,12 @@ const acceptsRawEcdsaSignature = async (
  * needless approval.
  *
  * `false` on RPC failure — the approve + execute fallback always works.
+ *
+ * Accepted downgrade: an implementation that *reverts* on a signer mismatch
+ * (`require(recovered == owner)` 7702 delegates, Sequence contract signatures)
+ * fails the probe although it would accept the real signature. Those accounts
+ * pay one exact-amount approval per step instead of using Permit2 — a gas cost
+ * on a route that works, not a failure.
  */
 export const canAccountUsePermit2 = async (
   client: SDKClient,

--- a/packages/sdk-provider-ethereum/src/permits/canAccountUsePermit2.unit.spec.ts
+++ b/packages/sdk-provider-ethereum/src/permits/canAccountUsePermit2.unit.spec.ts
@@ -95,10 +95,8 @@ describe('canAccountUsePermit2 — code-bearing accounts are probed, not assumed
   })
 
   it('blocks an account whose return is too short to be a magic value', async () => {
-    // A bare 4-byte return, not padded to a word. Permit2 compares a full
-    // 32-byte word, so a short return can never satisfy it on-chain —
-    // accepting it here would only manufacture a false positive, which is the
-    // same symptom this probe exists to prevent.
+    // A bare 4-byte return, not padded to a word. Permit2 could not decode it,
+    // so accepting it here would only manufacture a false positive.
     vi.mocked(getAccountCode).mockResolvedValue('0x6080' as `0x${string}`)
     vi.mocked(call).mockResolvedValue({ data: '0x1626ba7e' })
 
@@ -106,9 +104,7 @@ describe('canAccountUsePermit2 — code-bearing accounts are probed, not assumed
   })
 
   it('blocks a return one byte short of a full word', async () => {
-    // 31 bytes, not 32. Pins the acceptance boundary at exactly one word: a
-    // looser threshold would let this through, and Permit2's magic-value
-    // comparison still could not be satisfied by it on-chain.
+    // 31 bytes, not 32 — pins the boundary at exactly one word.
     vi.mocked(getAccountCode).mockResolvedValue('0x6080' as `0x${string}`)
     vi.mocked(call).mockResolvedValue({
       data: `0x${'ab'.repeat(31)}` as `0x${string}`,
@@ -118,22 +114,19 @@ describe('canAccountUsePermit2 — code-bearing accounts are probed, not assumed
   })
 
   it('never follows a CCIP-Read revert while probing', async () => {
-    // Following an `OffchainLookup` revert would make an outbound request to a
-    // URL this contract chose, and would turn a revert into a return —
-    // inverting the revert-vs-return rule the whole probe is keyed on.
+    // Following an `OffchainLookup` revert would turn a revert into a return,
+    // inverting the rule the probe is keyed on.
     vi.mocked(getAccountCode).mockResolvedValue(ALCHEMY_7702)
     vi.mocked(call).mockResolvedValue({ data: SIG_VALIDATION_FAILED })
-    // A sentinel client, so the assertion below also pins that the probe clones
-    // the real public client instead of replacing it with a bare object — the
-    // shared `{}` mock would let a dropped client pass.
+    // Sentinel, so the assertion also catches a client replaced rather than
+    // cloned — the shared `{}` mock would let that pass.
     vi.mocked(getPublicClient).mockResolvedValue({
       uid: 'probe-client',
     } as never)
 
     await subject()
 
-    // `ccipRead` is a client option in viem, not a call parameter, so it is
-    // asserted on the first argument — the client — not the second.
+    // viem takes `ccipRead` from the client, so assert on the first argument.
     expect(call).toHaveBeenCalledWith(
       expect.objectContaining({ uid: 'probe-client', ccipRead: false }),
       expect.anything()

--- a/packages/sdk-provider-ethereum/src/permits/canAccountUsePermit2.unit.spec.ts
+++ b/packages/sdk-provider-ethereum/src/permits/canAccountUsePermit2.unit.spec.ts
@@ -105,19 +105,37 @@ describe('canAccountUsePermit2 — code-bearing accounts are probed, not assumed
     expect(await subject()).toBe(false)
   })
 
+  it('blocks a return one byte short of a full word', async () => {
+    // 31 bytes, not 32. Pins the acceptance boundary at exactly one word: a
+    // looser threshold would let this through, and Permit2's magic-value
+    // comparison still could not be satisfied by it on-chain.
+    vi.mocked(getAccountCode).mockResolvedValue('0x6080' as `0x${string}`)
+    vi.mocked(call).mockResolvedValue({
+      data: `0x${'ab'.repeat(31)}` as `0x${string}`,
+    })
+
+    expect(await subject()).toBe(false)
+  })
+
   it('never follows a CCIP-Read revert while probing', async () => {
     // Following an `OffchainLookup` revert would make an outbound request to a
     // URL this contract chose, and would turn a revert into a return —
     // inverting the revert-vs-return rule the whole probe is keyed on.
     vi.mocked(getAccountCode).mockResolvedValue(ALCHEMY_7702)
     vi.mocked(call).mockResolvedValue({ data: SIG_VALIDATION_FAILED })
+    // A sentinel client, so the assertion below also pins that the probe clones
+    // the real public client instead of replacing it with a bare object — the
+    // shared `{}` mock would let a dropped client pass.
+    vi.mocked(getPublicClient).mockResolvedValue({
+      uid: 'probe-client',
+    } as never)
 
     await subject()
 
     // `ccipRead` is a client option in viem, not a call parameter, so it is
     // asserted on the first argument — the client — not the second.
     expect(call).toHaveBeenCalledWith(
-      expect.objectContaining({ ccipRead: false }),
+      expect.objectContaining({ uid: 'probe-client', ccipRead: false }),
       expect.anything()
     )
   })

--- a/packages/sdk-provider-ethereum/src/permits/canAccountUsePermit2.unit.spec.ts
+++ b/packages/sdk-provider-ethereum/src/permits/canAccountUsePermit2.unit.spec.ts
@@ -93,6 +93,34 @@ describe('canAccountUsePermit2 — code-bearing accounts are probed, not assumed
       expect.objectContaining({ to: ADDRESS })
     )
   })
+
+  it('blocks an account whose return is too short to be a magic value', async () => {
+    // A bare 4-byte return, not padded to a word. Permit2 compares a full
+    // 32-byte word, so a short return can never satisfy it on-chain —
+    // accepting it here would only manufacture a false positive, which is the
+    // same symptom this probe exists to prevent.
+    vi.mocked(getAccountCode).mockResolvedValue('0x6080' as `0x${string}`)
+    vi.mocked(call).mockResolvedValue({ data: '0x1626ba7e' })
+
+    expect(await subject()).toBe(false)
+  })
+
+  it('never follows a CCIP-Read revert while probing', async () => {
+    // Following an `OffchainLookup` revert would make an outbound request to a
+    // URL this contract chose, and would turn a revert into a return —
+    // inverting the revert-vs-return rule the whole probe is keyed on.
+    vi.mocked(getAccountCode).mockResolvedValue(ALCHEMY_7702)
+    vi.mocked(call).mockResolvedValue({ data: SIG_VALIDATION_FAILED })
+
+    await subject()
+
+    // `ccipRead` is a client option in viem, not a call parameter, so it is
+    // asserted on the first argument — the client — not the second.
+    expect(call).toHaveBeenCalledWith(
+      expect.objectContaining({ ccipRead: false }),
+      expect.anything()
+    )
+  })
 })
 
 describe('canAccountUsePermit2 — failure handling', () => {


### PR DESCRIPTION
## Which Linear task is linked to this PR?

[JUMEMB-32](https://linear.app/lifi-linear/issue/JUMEMB-32/mobile-wallet-permit2-issue-transactions-fail-on-jumper-in) — follow-up to #438, and targets that branch rather than `main`.

## Why was it implemented this way?

The signer probe also gated `relayed` steps, so a false verdict — one failed `eth_getCode` on a plain EOA is enough — moved the approval to `step.estimate.approvalAddress` while the relayer still pulls through Permit2. The pull then fails for missing allowance and the user paid for a useless approval. On `main` that spender was always `fromChain.permit2`.

Confirmed on a live relayer quote for USDT on Base: `PermitWitnessTransferFrom` typed data only, and `approvalAddress` is the Diamond. USDC masks it, because its `Permit` makes the allowance tasks skip entirely.

Guarding inside `resolvePermit2Support` fixes all three allowance tasks at once and leaves relayed behaviour byte-identical to `main`. Deriving the spender from the typed data instead would additionally fix relayed steps that never pull through Permit2 (Hyperliquid agent steps), but that is a second, pre-existing bug — deliberately out of scope here.

Also in scope, both on the probe itself: `ccipRead: false` so an `OffchainLookup` revert is not followed and inverted into a return (it is a viem *client* option, not a call parameter — as a call parameter it fails `tsc`, and would be silently dropped if it compiled), and the acceptance check now requires a full 32-byte word rather than 4 bytes.

## Visual showcase (Screenshots or Videos)

n/a

## Checklist before requesting a review

- [x] I have performed a self-review and testing of my code.
- [x] This pull request is focused and addresses a single problem.
- [x] If this PR modifies the SDK API or adds new features that require documentation, I have updated the documentation in the [public-docs](https://github.com/lifinance/public-docs) repository. — no public API change.

Not yet done: a preview pass on a **relayed USDT-on-Base** step. Unit coverage is 126 passing in `sdk-provider-ethereum`, but nothing has exercised this path on-chain.
