### PR TITLE
fix(solana): normalize RPC transaction handling

### DIFF
--- a/.changeset/tidy-solana-confirmation.md
+++ b/.changeset/tidy-solana-confirmation.md
@@ -1,0 +1,5 @@
+---
+'@lifi/sdk-provider-solana': patch
+---
+
+Fix Solana transaction submission option serialization and block height polling.

--- a/packages/sdk-provider-solana/src/actions/sendAndConfirmBundle.ts
+++ b/packages/sdk-provider-solana/src/actions/sendAndConfirmBundle.ts
@@ -70,10 +70,11 @@ export async function sendAndConfirmBundle(
             })
             .send(),
           jitoRpc
-            .getBlockHeight({
+            .getEpochInfo({
               commitment: 'confirmed',
             })
-            .send(),
+            .send()
+            .then((info) => info.blockHeight),
         ])
 
       let currentBlockHeight = initialBlockHeight
@@ -120,10 +121,11 @@ export async function sendAndConfirmBundle(
         await sleep(400)
         if (!abortController.signal.aborted) {
           currentBlockHeight = await jitoRpc
-            .getBlockHeight({
+            .getEpochInfo({
               commitment: 'confirmed',
             })
             .send()
+            .then((info) => info.blockHeight)
         }
       }
 

--- a/packages/sdk-provider-solana/src/actions/sendAndConfirmBundle.unit.spec.ts
+++ b/packages/sdk-provider-solana/src/actions/sendAndConfirmBundle.unit.spec.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it, vi } from 'vitest'
+
+const getBlockHeight = vi.fn(() => ({ send: vi.fn().mockResolvedValue(100n) }))
+const getEpochInfo = vi.fn(() => ({
+  send: vi.fn().mockResolvedValue({ blockHeight: 100n }),
+}))
+const getLatestBlockhash = vi.fn(() => ({
+  send: vi.fn().mockResolvedValue({
+    value: { blockhash: 'blockhash', lastValidBlockHeight: 200n },
+  }),
+}))
+const getBundleStatuses = vi.fn(() => ({
+  send: vi.fn().mockResolvedValue({
+    value: [
+      {
+        confirmation_status: 'confirmed',
+        transactions: ['signature'],
+      },
+    ],
+  }),
+}))
+const getSignatureStatuses = vi.fn(() => ({
+  send: vi.fn().mockResolvedValue({ value: [{ err: null }] }),
+}))
+const sendBundle = vi.fn(() => ({
+  send: vi.fn().mockResolvedValue('bundle-id'),
+}))
+
+const rpc = {
+  getBlockHeight,
+  getBundleStatuses,
+  getEpochInfo,
+  getLatestBlockhash,
+  getSignatureStatuses,
+  sendBundle,
+}
+
+vi.mock('../rpc/registry.js', () => ({
+  getJitoRpcs: vi.fn().mockResolvedValue([rpc]),
+}))
+
+vi.mock('@solana/kit', () => ({
+  getBase64EncodedWireTransaction: vi.fn().mockReturnValue('transaction'),
+}))
+
+vi.mock('@lifi/sdk', () => ({
+  sleep: vi.fn().mockResolvedValue(undefined),
+}))
+
+const { sendAndConfirmBundle } = await import('./sendAndConfirmBundle.js')
+
+describe('sendAndConfirmBundle', () => {
+  it('derives block height from epoch info', async () => {
+    await sendAndConfirmBundle({} as never, [{}] as never)
+
+    expect(getEpochInfo).toHaveBeenCalled()
+    expect(getBlockHeight).not.toHaveBeenCalled()
+  })
+})

--- a/packages/sdk-provider-solana/src/actions/sendAndConfirmTransaction.ts
+++ b/packages/sdk-provider-solana/src/actions/sendAndConfirmTransaction.ts
@@ -51,7 +51,8 @@ export async function sendAndConfirmTransaction(
     // https://solana.com/docs/advanced/retry#the-cost-of-skipping-preflight
     skipPreflight: true,
     // Setting max retries to 0 as we are handling retries manually
-    maxRetries: BigInt(0),
+    // @solana/kit types this as bigint, but RPC servers require a JSON number
+    maxRetries: 0 as unknown as bigint,
     // https://solana.com/docs/advanced/confirmation#use-an-appropriate-preflight-commitment-level
     preflightCommitment: 'confirmed' as Commitment,
     encoding: 'base64' as const,
@@ -78,10 +79,11 @@ export async function sendAndConfirmTransaction(
             })
             .send(),
           rpc
-            .getBlockHeight({
+            .getEpochInfo({
               commitment: 'confirmed',
             })
-            .send(),
+            .send()
+            .then((info) => info.blockHeight),
         ])
 
       let signatureResult: SignatureStatus | null = null
@@ -129,10 +131,11 @@ export async function sendAndConfirmTransaction(
           await sleep(1000)
           if (!abortController.signal.aborted) {
             blockHeight = await rpc
-              .getBlockHeight({
+              .getEpochInfo({
                 commitment: 'confirmed',
               })
               .send()
+              .then((info) => info.blockHeight)
           }
         }
         return null

--- a/packages/sdk-provider-solana/src/actions/sendAndConfirmTransaction.unit.spec.ts
+++ b/packages/sdk-provider-solana/src/actions/sendAndConfirmTransaction.unit.spec.ts
@@ -1,0 +1,71 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const send = vi.fn().mockResolvedValue('signature')
+const getBlockHeight = vi.fn(() => ({ send: vi.fn().mockResolvedValue(100n) }))
+const getEpochInfo = vi.fn(() => ({
+  send: vi.fn().mockResolvedValue({ blockHeight: 100n }),
+}))
+const getLatestBlockhash = vi.fn(() => ({
+  send: vi.fn().mockResolvedValue({
+    value: { blockhash: 'blockhash', lastValidBlockHeight: 200n },
+  }),
+}))
+const getSignatureStatuses = vi.fn(() => ({
+  send: vi.fn().mockResolvedValue({
+    value: [
+      {
+        confirmationStatus: 'confirmed',
+        confirmations: 1n,
+        err: null,
+        slot: 1n,
+        status: { Ok: null },
+      },
+    ],
+  }),
+}))
+const sendTransaction = vi.fn(() => ({ send }))
+
+const rpc = {
+  getBlockHeight,
+  getEpochInfo,
+  getLatestBlockhash,
+  getSignatureStatuses,
+  sendTransaction,
+}
+
+vi.mock('../rpc/registry.js', () => ({
+  getSolanaRpcs: vi.fn().mockResolvedValue([rpc]),
+}))
+
+vi.mock('@solana/kit', () => ({
+  getBase64EncodedWireTransaction: vi.fn().mockReturnValue('transaction'),
+  getSignatureFromTransaction: vi.fn().mockReturnValue('signature'),
+}))
+
+vi.mock('@lifi/sdk', () => ({
+  sleep: vi.fn().mockResolvedValue(undefined),
+}))
+
+const { sendAndConfirmTransaction } = await import(
+  './sendAndConfirmTransaction.js'
+)
+
+describe('sendAndConfirmTransaction', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('passes maxRetries as a JSON-RPC number', async () => {
+    await sendAndConfirmTransaction({} as never, {} as never)
+
+    expect(sendTransaction).toHaveBeenCalled()
+    expect(sendTransaction.mock.calls[0][1].maxRetries).toBe(0)
+  })
+
+  it('derives block height from epoch info', async () => {
+    await sendAndConfirmTransaction({} as never, {} as never)
+
+    expect(getEpochInfo).toHaveBeenCalled()
+    expect(getBlockHeight).not.toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
## Summary
- send `maxRetries` as a JSON number so strict Solana RPC servers accept `sendTransaction`
- derive transaction and bundle expiry checks from `getEpochInfo().blockHeight`
- add unit coverage for option serialization and block-height polling

## Context
`@solana/kit` types `maxRetries` as `bigint`, which serializes to `\"0\"`. Solana RPC servers expect a JSON number and reject the request with `-32602 Invalid params`.

We also observed proxied RPC endpoints intermittently returning the slot for single-request `getBlockHeight` calls. Since slots exceed `lastValidBlockHeight`, this prematurely terminates the confirmation loop. `getEpochInfo().blockHeight` remained consistent across the same endpoints.

These changes were validated with two confirmed Solana swaps through the existing RPC path.

## Test plan
- [x] `pnpm --filter @lifi/sdk-provider-solana test:unit` (58 passed)
- [x] `pnpm --filter @lifi/sdk-provider-solana check:types`
- [x] `pnpm --filter @lifi/sdk-provider-solana build`
- [x] `pnpm check`
- [x] workspace type and circular dependency checks via pre-commit hook