### PR TITLE
chore: type-check spec files in the remaining six packages

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,7 @@
 # CLAUDE.md
 
 ## Project
-TypeScript monorepo (pnpm workspaces) with 6 packages under `packages/`. `@lifi/sdk`
+TypeScript monorepo (pnpm workspaces) with 7 packages under `packages/`. `@lifi/sdk`
 is the hub; each provider depends on it via `workspace:*` as a **regular** dependency
 (not peer), which resolves to the exact pinned version in published tarballs.
 
@@ -38,7 +38,7 @@ and the Linear anchor policy live in the **`release` skill**
 (`.claude/skills/release/SKILL.md`). Read it before touching the publish path.
 
 ### External pinned deps — bump MANUALLY (out of Changesets scope)
-- `@lifi/types` (17.x, in `@lifi/sdk` deps) and `@lifi/data-types` (devDep) are external
+- `@lifi/types` (18.x, in `@lifi/sdk` deps) and `@lifi/data-types` (devDep) are external
   pinned versions. Changesets does **not** track or bump them. When upgrading, edit the
   pins by hand and add a `fix:`/`feat:` changeset describing the bump.
 

--- a/packages/sdk-provider-bitcoin/package.json
+++ b/packages/sdk-provider-bitcoin/package.json
@@ -37,7 +37,8 @@
     "test": "vitest --run --dangerouslyIgnoreUnhandledErrors",
     "test:cov": "pnpm test --coverage",
     "test:unit": "pnpm test .unit.spec.ts --passWithNoTests",
-    "check:types": "tsc --noEmit",
+    "check:types": "tsc --noEmit && tsc -p tsconfig.spec.json --noEmit",
+    "check:types:specs": "tsc -p tsconfig.spec.json --noEmit",
     "check:circular-deps": "madge --circular $(find ./src -name '*.ts')",
     "check:circular-deps-graph": "madge --circular $(find ./src -name '*.ts') --image graph.svg",
     "watch": "tsdown --watch"

--- a/packages/sdk-provider-bitcoin/tsconfig.spec.json
+++ b/packages/sdk-provider-bitcoin/tsconfig.spec.json
@@ -1,0 +1,22 @@
+{
+  // Type-checks the files `tsconfig.json` excludes: `*.spec.ts`, `*.mock.ts`
+  // and `*.handlers.ts`. Vitest transpiles without type-checking, so without
+  // this config nothing in the repo ever type-checks a test file — which is how
+  // a wrong type assertion can sit in a green test asserting something other
+  // than what it claims.
+  //
+  // Everything else is inherited unchanged, so tests are held to the same
+  // `strict` / `isolatedDeclarations` / `noUnusedLocals` bar as `src`. Only two
+  // things are overridden: `exclude` (to stop dropping the test files) and
+  // `tsBuildInfoFile` (the inherited path is the one `check:types` writes —
+  // sharing it would make the two runs invalidate each other's cache).
+  //
+  // Run with `--noEmit` (see the `check:types:specs` script): a composite
+  // project may not set `noEmit` in its config, only on the command line.
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.spec.tsbuildinfo"
+  },
+  "include": ["./src/**/*", "./src/**/*.json"],
+  "exclude": ["tests"]
+}

--- a/packages/sdk-provider-ethereum/package.json
+++ b/packages/sdk-provider-ethereum/package.json
@@ -37,7 +37,8 @@
     "test": "vitest --run --dangerouslyIgnoreUnhandledErrors",
     "test:cov": "pnpm test --coverage",
     "test:unit": "pnpm test .unit.spec.ts --passWithNoTests",
-    "check:types": "tsc --noEmit",
+    "check:types": "tsc --noEmit && tsc -p tsconfig.spec.json --noEmit",
+    "check:types:specs": "tsc -p tsconfig.spec.json --noEmit",
     "check:circular-deps": "madge --circular $(find ./src -name '*.ts')",
     "check:circular-deps-graph": "madge --circular $(find ./src -name '*.ts') --image graph.svg",
     "watch": "tsdown --watch"

--- a/packages/sdk-provider-ethereum/tsconfig.spec.json
+++ b/packages/sdk-provider-ethereum/tsconfig.spec.json
@@ -1,0 +1,22 @@
+{
+  // Type-checks the files `tsconfig.json` excludes: `*.spec.ts`, `*.mock.ts`
+  // and `*.handlers.ts`. Vitest transpiles without type-checking, so without
+  // this config nothing in the repo ever type-checks a test file — which is how
+  // a wrong type assertion can sit in a green test asserting something other
+  // than what it claims.
+  //
+  // Everything else is inherited unchanged, so tests are held to the same
+  // `strict` / `isolatedDeclarations` / `noUnusedLocals` bar as `src`. Only two
+  // things are overridden: `exclude` (to stop dropping the test files) and
+  // `tsBuildInfoFile` (the inherited path is the one `check:types` writes —
+  // sharing it would make the two runs invalidate each other's cache).
+  //
+  // Run with `--noEmit` (see the `check:types:specs` script): a composite
+  // project may not set `noEmit` in its config, only on the command line.
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.spec.tsbuildinfo"
+  },
+  "include": ["./src/**/*", "./src/**/*.json"],
+  "exclude": ["tests"]
+}

--- a/packages/sdk-provider-stellar/package.json
+++ b/packages/sdk-provider-stellar/package.json
@@ -37,7 +37,8 @@
     "test": "vitest --run --dangerouslyIgnoreUnhandledErrors",
     "test:cov": "pnpm test --coverage",
     "test:unit": "pnpm test .unit.spec.ts --passWithNoTests",
-    "check:types": "tsc --noEmit",
+    "check:types": "tsc --noEmit && tsc -p tsconfig.spec.json --noEmit",
+    "check:types:specs": "tsc -p tsconfig.spec.json --noEmit",
     "check:circular-deps": "madge --circular $(find ./src -name '*.ts')",
     "check:circular-deps-graph": "madge --circular $(find ./src -name '*.ts') --image graph.svg",
     "watch": "tsdown --watch"

--- a/packages/sdk-provider-stellar/src/actions/getStellarBalance.unit.spec.ts
+++ b/packages/sdk-provider-stellar/src/actions/getStellarBalance.unit.spec.ts
@@ -1,4 +1,4 @@
-import type { Token } from '@lifi/sdk'
+import { ChainId, type Token } from '@lifi/sdk'
 import { Keypair, nativeToScVal, StrKey } from '@stellar/stellar-sdk'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
@@ -16,13 +16,14 @@ const { getStellarBalance } = await import('./getStellarBalance.js')
 const WALLET = Keypair.random().publicKey()
 const PASSPHRASE = 'Test SDF Network ; September 2015'
 
-const token = (fill: number): Token =>
-  ({
-    address: StrKey.encodeContract(Buffer.alloc(32, fill)),
-    chainId: 1500,
-    decimals: 7,
-    symbol: 'TKN',
-  }) as Token
+const token = (fill: number): Token => ({
+  address: StrKey.encodeContract(Buffer.alloc(32, fill)),
+  chainId: ChainId.XLM,
+  decimals: 7,
+  symbol: 'TKN',
+  name: 'Token',
+  priceUSD: '1',
+})
 
 const balanceOf = (amount: bigint) => ({
   transactionData: {},

--- a/packages/sdk-provider-stellar/src/core/StellarStepExecutor.unit.spec.ts
+++ b/packages/sdk-provider-stellar/src/core/StellarStepExecutor.unit.spec.ts
@@ -34,6 +34,21 @@ const contextWith = (actions: object[] = []) =>
     isBridgeExecution: false,
   }) as never
 
+/**
+ * Runs `call` and returns whatever it threw, or `undefined` when it returned
+ * normally. The explicit `undefined` keeps the caller's `toBeInstanceOf`
+ * assertion failing on a `checkWallet` that let the mismatch through, instead
+ * of relying on an implicit fall-through return.
+ */
+const thrownBy = (call: () => void): unknown => {
+  try {
+    call()
+  } catch (error) {
+    return error
+  }
+  return undefined
+}
+
 describe('StellarStepExecutor', () => {
   describe('createPipeline', () => {
     it('orders the allowance tasks BEFORE preparing the transaction', () => {
@@ -102,13 +117,9 @@ describe('StellarStepExecutor', () => {
       const executor = makeExecutor()
       const other = Keypair.random().publicKey()
 
-      const thrown = (() => {
-        try {
-          executor.checkWallet({ action: { fromAddress: other } } as never)
-        } catch (error) {
-          return error
-        }
-      })()
+      const thrown = thrownBy(() =>
+        executor.checkWallet({ action: { fromAddress: other } } as never)
+      )
 
       expect(thrown).toBeInstanceOf(TransactionError)
       expect((thrown as TransactionError).code).toBe(
@@ -130,15 +141,11 @@ describe('StellarStepExecutor', () => {
         routeId: 'route-1',
       })
 
-      const thrown = (() => {
-        try {
-          executor.checkWallet({
-            action: { fromAddress: keypair.publicKey() },
-          } as never)
-        } catch (error) {
-          return error
-        }
-      })()
+      const thrown = thrownBy(() =>
+        executor.checkWallet({
+          action: { fromAddress: keypair.publicKey() },
+        } as never)
+      )
 
       expect(thrown).toBeInstanceOf(TransactionError)
       expect((thrown as TransactionError).code).toBe(

--- a/packages/sdk-provider-stellar/src/core/tasks/StellarPrepareTransactionTask.unit.spec.ts
+++ b/packages/sdk-provider-stellar/src/core/tasks/StellarPrepareTransactionTask.unit.spec.ts
@@ -1,6 +1,14 @@
+import type { TaskResult } from '@lifi/sdk'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { StellarStepExecutorContext } from '../../types.js'
+import type { assertApprovalStillCovers as AssertApprovalStillCovers } from './helpers/assertApprovalStillCovers.js'
 
-const baseRun = vi.fn(async () => ({ status: 'COMPLETED' }))
+// Typed from the real signatures the stubs stand in for, so that
+// `toHaveBeenCalledWith` below is checked against the arguments those
+// functions actually take, and the mocked `TaskResult` against its real shape.
+const baseRun = vi.fn<
+  (context: StellarStepExecutorContext) => Promise<TaskResult>
+>(async () => ({ status: 'COMPLETED' }))
 
 // Stub the base class so this suite tests the override, not the shared task.
 // `PrepareTransactionTask.unit.spec.ts` in @lifi/sdk covers the base body — a
@@ -9,20 +17,25 @@ const baseRun = vi.fn(async () => ({ status: 'COMPLETED' }))
 vi.mock('@lifi/sdk', async () => {
   const actual = await vi.importActual<typeof import('@lifi/sdk')>('@lifi/sdk')
   class PrepareTransactionTask {
-    protected shouldRefetchTransaction(_context: unknown): boolean {
+    protected shouldRefetchTransaction(
+      _context: StellarStepExecutorContext
+    ): boolean {
       return false
     }
-    async run(context: unknown): Promise<unknown> {
-      return baseRun(context as never)
+    async run(context: StellarStepExecutorContext): Promise<TaskResult> {
+      return baseRun(context)
     }
   }
   return { ...actual, PrepareTransactionTask }
 })
 
-const assertApprovalStillCovers = vi.fn(async () => undefined)
+const assertApprovalStillCovers = vi.fn<typeof AssertApprovalStillCovers>(
+  async () => undefined
+)
 vi.mock('./helpers/assertApprovalStillCovers.js', () => ({
-  assertApprovalStillCovers: (...args: unknown[]) =>
-    assertApprovalStillCovers(...args),
+  assertApprovalStillCovers: (
+    ...args: Parameters<typeof AssertApprovalStillCovers>
+  ) => assertApprovalStillCovers(...args),
 }))
 
 const { StellarPrepareTransactionTask } = await import(

--- a/packages/sdk-provider-stellar/tsconfig.spec.json
+++ b/packages/sdk-provider-stellar/tsconfig.spec.json
@@ -1,0 +1,30 @@
+{
+  // Type-checks the files `tsconfig.json` excludes: `*.spec.ts`, `*.mock.ts`
+  // and `*.handlers.ts`. Vitest transpiles without type-checking, so without
+  // this config nothing in the repo ever type-checks a test file — which is how
+  // a wrong type assertion can sit in a green test asserting something other
+  // than what it claims.
+  //
+  // Everything else is inherited unchanged, so tests are held to the same
+  // `strict` / `isolatedDeclarations` / `noUnusedLocals` bar as `src`. Only
+  // three things are overridden: `exclude` (to stop dropping the test files),
+  // `tsBuildInfoFile` (the inherited path is the one `check:types` writes —
+  // sharing it would make the two runs invalidate each other's cache) and
+  // `types`.
+  //
+  // `types` is set here rather than in `tsconfig.json` because only the test
+  // files reach for node globals (`Buffer`) — `src` compiles clean without
+  // them, and widening the base config would change non-test compilation.
+  // `@types/node` resolves from the workspace root, so no devDependency is
+  // needed.
+  //
+  // Run with `--noEmit` (see the `check:types:specs` script): a composite
+  // project may not set `noEmit` in its config, only on the command line.
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.spec.tsbuildinfo",
+    "types": ["node"]
+  },
+  "include": ["./src/**/*", "./src/**/*.json"],
+  "exclude": ["tests"]
+}

--- a/packages/sdk-provider-sui/package.json
+++ b/packages/sdk-provider-sui/package.json
@@ -37,7 +37,8 @@
     "test": "vitest --run --dangerouslyIgnoreUnhandledErrors",
     "test:cov": "pnpm test --coverage",
     "test:unit": "pnpm test .unit.spec.ts --passWithNoTests",
-    "check:types": "tsc --noEmit",
+    "check:types": "tsc --noEmit && tsc -p tsconfig.spec.json --noEmit",
+    "check:types:specs": "tsc -p tsconfig.spec.json --noEmit",
     "check:circular-deps": "madge --circular $(find ./src -name '*.ts')",
     "check:circular-deps-graph": "madge --circular $(find ./src -name '*.ts') --image graph.svg",
     "watch": "tsdown --watch"

--- a/packages/sdk-provider-sui/tsconfig.spec.json
+++ b/packages/sdk-provider-sui/tsconfig.spec.json
@@ -1,0 +1,22 @@
+{
+  // Type-checks the files `tsconfig.json` excludes: `*.spec.ts`, `*.mock.ts`
+  // and `*.handlers.ts`. Vitest transpiles without type-checking, so without
+  // this config nothing in the repo ever type-checks a test file — which is how
+  // a wrong type assertion can sit in a green test asserting something other
+  // than what it claims.
+  //
+  // Everything else is inherited unchanged, so tests are held to the same
+  // `strict` / `isolatedDeclarations` / `noUnusedLocals` bar as `src`. Only two
+  // things are overridden: `exclude` (to stop dropping the test files) and
+  // `tsBuildInfoFile` (the inherited path is the one `check:types` writes —
+  // sharing it would make the two runs invalidate each other's cache).
+  //
+  // Run with `--noEmit` (see the `check:types:specs` script): a composite
+  // project may not set `noEmit` in its config, only on the command line.
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.spec.tsbuildinfo"
+  },
+  "include": ["./src/**/*", "./src/**/*.json"],
+  "exclude": ["tests"]
+}

--- a/packages/sdk-provider-tron/package.json
+++ b/packages/sdk-provider-tron/package.json
@@ -37,7 +37,8 @@
     "test": "vitest --run --dangerouslyIgnoreUnhandledErrors",
     "test:cov": "pnpm test --coverage",
     "test:unit": "pnpm test .unit.spec.ts --passWithNoTests",
-    "check:types": "tsc --noEmit",
+    "check:types": "tsc --noEmit && tsc -p tsconfig.spec.json --noEmit",
+    "check:types:specs": "tsc -p tsconfig.spec.json --noEmit",
     "check:circular-deps": "madge --circular $(find ./src -name '*.ts')",
     "check:circular-deps-graph": "madge --circular $(find ./src -name '*.ts') --image graph.svg",
     "watch": "tsdown --watch"

--- a/packages/sdk-provider-tron/tsconfig.spec.json
+++ b/packages/sdk-provider-tron/tsconfig.spec.json
@@ -1,0 +1,22 @@
+{
+  // Type-checks the files `tsconfig.json` excludes: `*.spec.ts`, `*.mock.ts`
+  // and `*.handlers.ts`. Vitest transpiles without type-checking, so without
+  // this config nothing in the repo ever type-checks a test file — which is how
+  // a wrong type assertion can sit in a green test asserting something other
+  // than what it claims.
+  //
+  // Everything else is inherited unchanged, so tests are held to the same
+  // `strict` / `isolatedDeclarations` / `noUnusedLocals` bar as `src`. Only two
+  // things are overridden: `exclude` (to stop dropping the test files) and
+  // `tsBuildInfoFile` (the inherited path is the one `check:types` writes —
+  // sharing it would make the two runs invalidate each other's cache).
+  //
+  // Run with `--noEmit` (see the `check:types:specs` script): a composite
+  // project may not set `noEmit` in its config, only on the command line.
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.spec.tsbuildinfo"
+  },
+  "include": ["./src/**/*", "./src/**/*.json"],
+  "exclude": ["tests"]
+}

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -37,7 +37,8 @@
     "test": "vitest --run --dangerouslyIgnoreUnhandledErrors",
     "test:cov": "pnpm test --coverage",
     "test:unit": "pnpm test .unit.spec.ts --passWithNoTests",
-    "check:types": "tsc --noEmit",
+    "check:types": "tsc --noEmit && tsc -p tsconfig.spec.json --noEmit",
+    "check:types:specs": "tsc -p tsconfig.spec.json --noEmit",
     "check:circular-deps": "madge --circular $(find ./src -name '*.ts')",
     "check:circular-deps-graph": "madge --circular $(find ./src -name '*.ts') --image graph.svg",
     "watch": "tsdown --watch"

--- a/packages/sdk/src/actions/actions.unit.handlers.ts
+++ b/packages/sdk/src/actions/actions.unit.handlers.ts
@@ -1,16 +1,19 @@
 import { findDefaultToken } from '@lifi/data-types'
 import { ChainId, CoinKey } from '@lifi/types'
-import { HttpResponse, http } from 'msw'
-import { setupServer } from 'msw/node'
+import { HttpResponse, http, type RequestHandler } from 'msw'
+import { type SetupServer, setupServer } from 'msw/node'
 import { afterAll, afterEach, beforeAll, beforeEach, vi } from 'vitest'
 import { createClient } from '../client/createClient.js'
+import type { SDKClient } from '../types/core.js'
 import { requestSettings } from '../utils/request.js'
 
-const client = createClient({
+// `client`, `handlers` and `setupTestServer` are annotated because they are
+// exported and `isolatedDeclarations` is inherited from the base config.
+const client: SDKClient = createClient({
   integrator: 'lifi-sdk',
 })
 
-export const handlers = [
+export const handlers: RequestHandler[] = [
   http.post(`${client.config.apiUrl}/advanced/routes`, async () => {
     return HttpResponse.json({})
   }),
@@ -54,7 +57,7 @@ export const handlers = [
  * Sets up MSW server with common handlers for HTTP-based tests
  * Call this function at the top level of your test file
  */
-export const setupTestServer = () => {
+export const setupTestServer = (): SetupServer => {
   const server = setupServer(...handlers)
 
   beforeAll(() => {

--- a/packages/sdk/src/actions/getStepTransaction.unit.spec.ts
+++ b/packages/sdk/src/actions/getStepTransaction.unit.spec.ts
@@ -144,7 +144,19 @@ describe('getStepTransaction', () => {
     const getSolanaStep = (): LiFiStep =>
       getStep({ action: getAction({ fromChainId: ChainId.SOL }) })
 
-    const requestedUrl = (): string => mockedFetch.mock.calls[0][1]
+    // `request` accepts `RequestInfo | URL`; every call site here passes a
+    // string. Narrowing rather than coercing keeps the assertions below
+    // meaningful — `String(new Request(...))` is '[object Request]', which
+    // would quietly satisfy `not.toContain('svmPriorityFeeLevel')`.
+    const requestedUrl = (): string => {
+      const url = mockedFetch.mock.calls[0][1]
+      if (typeof url !== 'string') {
+        throw new TypeError(
+          `expected request() to receive a string URL, received ${typeof url}`
+        )
+      }
+      return url
+    }
 
     it.each([
       SVMPriorityFeeLevel.NORMAL,

--- a/packages/sdk/tsconfig.spec.json
+++ b/packages/sdk/tsconfig.spec.json
@@ -1,0 +1,22 @@
+{
+  // Type-checks the files `tsconfig.json` excludes: `*.spec.ts`, `*.mock.ts`
+  // and `*.handlers.ts`. Vitest transpiles without type-checking, so without
+  // this config nothing in the repo ever type-checks a test file — which is how
+  // a wrong type assertion can sit in a green test asserting something other
+  // than what it claims.
+  //
+  // Everything else is inherited unchanged, so tests are held to the same
+  // `strict` / `isolatedDeclarations` / `noUnusedLocals` bar as `src`. Only two
+  // things are overridden: `exclude` (to stop dropping the test files) and
+  // `tsBuildInfoFile` (the inherited path is the one `check:types` writes —
+  // sharing it would make the two runs invalidate each other's cache).
+  //
+  // Run with `--noEmit` (see the `check:types:specs` script): a composite
+  // project may not set `noEmit` in its config, only on the command line.
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.spec.tsbuildinfo"
+  },
+  "include": ["./src/**/*", "./src/**/*.json"],
+  "exclude": ["tests"]
+}


### PR DESCRIPTION
Two repo-hygiene chores. No changeset: only `CLAUDE.md`, test files
(`*.spec.ts` / `*.handlers.ts`), `tsconfig.spec.json` and `package.json` scripts
change. No publishable runtime source is touched — verified that
`actions.unit.handlers.ts` is absent from `packages/sdk/dist`.

## 1. `CLAUDE.md` undercounted the packages

`ls -d packages/*/` returns **7**, not 6 — `sdk-provider-stellar` was added in
#427 and the Project paragraph was never updated.

The rest of that paragraph still holds, checked rather than assumed: all six
providers declare `@lifi/sdk` as `workspace:*` under `dependencies`, and none
declares it under `peerDependencies` or `devDependencies`.

**Found while checking, outside the brief:** the "External pinned deps" note
claimed `@lifi/types` was `17.x`. `packages/sdk/package.json` pins `18.2.0`.
The exact-pin claim itself was accurate; only the major was stale. Fixed in the
same commit.

## 2. Spec type-checking extended to six packages

Every `tsconfig.json` excludes `*.spec.ts`, `*.mock.ts` and `*.handlers.ts`, and
vitest transpiles without type-checking. So no gate in this repo type-checked a
test file — **11,144 lines** across these six packages. A wrong type assertion is
erased at runtime, so such a test passes green while asserting something other
than what it claims.

This replicates the `tsconfig.spec.json` added for `sdk-provider-solana` in #448,
plus its wiring:

```json
"check:types": "tsc --noEmit && tsc -p tsconfig.spec.json --noEmit",
"check:types:specs": "tsc -p tsconfig.spec.json --noEmit"
```

**Six of seven packages.** `sdk-provider-solana` is not in this diff — its
identical config lives in #448, which is still in review. On this branch its
`check:types` remains `tsc --noEmit` alone. The asymmetry resolves when #448
merges; it is not an oversight.

### Measured error counts

The brief estimated 24. The first run reproduces exactly that. It is an
undercount, and the reason is worth knowing:

> **`tsc` withholds `--isolatedDeclarations` diagnostics while any semantic error
> remains in the program.** Error counts are therefore not monotonic — they must
> be re-measured after each fix, not assumed to only go down.

Verified by stashing the one-line sdk fix and watching the three TS9xxx errors
disappear, then reappear on restore.

| package | first run | after `types: ["node"]` | after semantic fixes | true total |
|---|---|---|---|---|
| `sdk-provider-stellar` | 23 | 5 | 0 | **23** |
| `sdk` | 1 | — | 3 appeared, then 0 | **4** |
| `sdk-provider-ethereum` | 0 | — | — | 0 |
| `sdk-provider-bitcoin` | 0 | — | — | 0 |
| `sdk-provider-tron` | 0 | — | — | 0 |
| `sdk-provider-sui` | 0 | — | — | 0 |
| **total** | **24** | | | **27** |

Stellar's 18 `Buffer` errors all came from one missing `types: ["node"]`, as the
brief predicted (it said 14; measured 18). Nothing was masked behind them —
stellar reaches 0 with no further errors appearing.

### What was fixed

- **`stellar/getStellarBalance.unit.spec.ts`** — an `as Token` cast on the token
  fixture hid two missing required fields (`name`, `priceUSD`) and let a
  placeholder `chainId` of `1500` stand in a Stellar fixture, where the sibling
  `.int.spec.ts` uses `ChainId.XLM` (`1201081091099710`). No behavioural
  consequence — `getStellarBalance` never reads `chainId` — but the cast froze
  the fixture against every future change to `Token`.
- **`stellar/StellarStepExecutor.unit.spec.ts`** — two throw-capturing IIFEs fell
  through without returning (TS7030). Extracted as a `thrownBy` helper with an
  explicit `undefined`, so a `checkWallet` that stops throwing still fails the
  test rather than relying on an implicit fall-through.
- **`stellar/StellarPrepareTransactionTask.unit.spec.ts`** — `baseRun` and
  `assertApprovalStillCovers` were declared zero-arity but called with one
  argument. Typed from the real signatures (`typeof` the actual helper) so
  `toHaveBeenCalledWith` is now checked against the arguments those functions
  really take, instead of a rest-param that accepts any arity forever.
- **`sdk/getStepTransaction.unit.spec.ts`** — `requestedUrl()` claimed `string`
  for a `RequestInfo | URL`. Narrowed rather than coerced: `String(new
  Request(...))` is `'[object Request]'`, which would quietly satisfy the
  `not.toContain('svmPriorityFeeLevel')` assertion directly below it.
- **`sdk/actions.unit.handlers.ts`** — three `isolatedDeclarations` errors on
  exported values, fixed with explicit `SDKClient`, `RequestHandler[]` and
  `SetupServer` annotations.

### Did any test assert the wrong thing?

**No.** Of the 27 errors, none was a test asserting something false. The three
assertions whose types were actually broken were mutation-tested, and all three
go red when the behaviour they claim to check regresses:

| assertion | mutation | result |
|---|---|---|
| `expect(baseRun).toHaveBeenCalledWith(context)` | forward `{...context, mutated: true}` to `super.run` | ✅ fails, passes again on revert |
| `expect(assertApprovalStillCovers).toHaveBeenCalledWith(context)` | same | ✅ fails, passes again on revert |
| `expect(requestedUrl()).not.toContain('svmPriorityFeeLevel')` | always set the query param | ✅ fails, passes again on revert |

So the mock-arity drift was real *type* drift that never produced a
passing-yet-wrong assertion. This differs from solana, where the same gate found
three genuine defects. That difference is a result of this pass, not a shortfall
in it — these six packages were simply cleaner.

### Two stated decisions

**`isolatedDeclarations` stays inherited (`true`).** It produced 3 errors in
11,144 lines, all in one file, all fixed with explicit annotations that are an
improvement in their own right. That is not enough friction to justify
`"isolatedDeclarations": false` and holding test helpers to a lower bar than
`src`.

**`types: ["node"]` goes in stellar's spec config only, not its base config.**
Only stellar's test files reach for node globals (`Buffer`); its `src` uses none
and compiles clean without them. Widening the base config would have changed
non-test compilation and weakened the "chore/config, no changeset" position.
`@types/node` resolves from the workspace root, so no devDependency and no
lockfile change is needed. This is the one place the six configs are not
identical, and the file's comment says why.

## What spec type-checking does and does not catch

It catches: wrong types on fixtures and helpers, mock signatures that drift from
the functions they stand in for, missing required fields, unused imports, and
implicit-return mistakes — none of which vitest sees, because it transpiles
without type-checking.

It does **not** catch:

1. **A bad string-literal-union assertion behind a cast.** Both
   `'bogus' as Commitment` and `'bogus' as Commitment & string` compile clean
   (verified with this repo's own `tsc` during the solana work).
2. **Anything behind `as never`.** `never` is assignable to every parameter
   type. `{ step: {} } as never` in
   `StellarPrepareTransactionTask.unit.spec.ts` is precisely why the zero-arity
   `baseRun` slipped past `toHaveBeenCalledWith` in the first place. Those casts
   survive deliberately — building a full `StellarStepExecutorContext` is heavy
   — and `contextWith(...) as never` in `StellarStepExecutor.unit.spec.ts` is
   blind the same way.
3. **Errors hidden behind other errors.** One semantic error suppresses every
   `isolatedDeclarations` error in that package, so a package that goes green
   after a single fix is not proven clean until it is re-run.
4. **Anything about runtime behaviour.** A correctly-typed assertion that checks
   the wrong thing still passes.

## Verification

Per package — `check:types` passes, and the suite passes with no `Errors`
section:

| package | `check:types` | suite | `Errors` section |
|---|---|---|---|
| `sdk` | ✅ | 239 passed, 5 skipped | none |
| `sdk-provider-bitcoin` | ✅ | 15 passed | none |
| `sdk-provider-ethereum` | ✅ | 137 passed | none |
| `sdk-provider-solana` | ✅ | 59 passed | none |
| `sdk-provider-stellar` | ✅ | 91 passed, 3 skipped | none |
| `sdk-provider-sui` | ✅ | 13 passed | none |
| `sdk-provider-tron` | ✅ | 36 passed | none |

Repo-wide, all green: `pnpm check`, `check:types`, `check:circular-deps`,
`knip:check`, `build`, `test:unit`.

Four checks on the verification itself, so that none of the above is a green
light that could never have gone red:

- **The gate is live.** A deliberate `const n: number = 'not a number'` in a
  bitcoin spec fails both `check:types` and `check:types:specs` — while
  `vitest --run` passes the same file. That is exactly the hole this closes.
- **Coverage is complete.** `tsc --listFiles` confirms all 109
  `*.spec.ts` / `*.mock.ts` / `*.handlers.ts` files are in the spec programs and
  **0** are in the base programs. No package keeps test files outside `src/`,
  and no package has a `tests/` directory, so the inherited
  `exclude: ["tests"]` is vestigial.
- **The `Errors` grep can fire.** `pnpm --filter <pkg> exec vitest --run` does
  **not** pick up the root `vitest.config.ts` (its root dir is the package dir),
  so `dangerouslyIgnoreUnhandledErrors: true` is not applied. A probe leaking an
  unhandled rejection printed `Errors 1 error` — and **exited 0**, confirming
  that the exit code is not a signal for leaked rejections in vitest 4.1.10 and
  the grep is required. The packages' own `test` script passes
  `--dangerouslyIgnoreUnhandledErrors`, which is why the unsuppressed command
  was used here.
- **The two caches are separate.** Both `tsconfig.tsbuildinfo` and
  `tsconfig.spec.tsbuildinfo` exist per package after a run, and a warm-cache
  re-run of `check:types` stays green — the two runs do not invalidate each
  other.

The pre-commit hook ran the full new gate on both commits in this PR, which is
direct evidence that chaining into `check:types` reaches the hook without editing
`.husky/` or the workflow.
