### PR TITLE
feat(stellar): require the account reserve before spending XLM

### DIFF
--- a/.changeset/stellar-native-reserve.md
+++ b/.changeset/stellar-native-reserve.md
@@ -1,0 +1,8 @@
+---
+"@lifi/sdk-provider-stellar": minor
+"@lifi/sdk": minor
+---
+
+Account for the Stellar native reserve before spending XLM. `SDKProvider` gains an optional `getNativeReserve`, which the Stellar provider implements by reading the sender's account entry and computing `(2 + numSubEntries + numSponsoring - numSponsored) x baseReserve + sellingLiabilities`, plus one base reserve of headroom for the trustline `LiFi::internal_swap` opens on the sender's behalf (`try_trust`) inside the transaction being checked.
+
+`checkBalance` now requires that reserve on top of the source amount, gas and non-included fees whenever a step spends the chain's native token, and preserves it when trimming the source amount by slippage. Previously a swap of nearly the whole XLM balance passed every pre-flight check and then failed in simulation with an opaque `HostError: Error(Contract, #10)` from the native Stellar Asset Contract; it now fails fast with a balance error naming the reserve, and the slippage rescue no longer proposes an amount that drains the account below it.

--- a/packages/sdk-provider-stellar/src/StellarProvider.ts
+++ b/packages/sdk-provider-stellar/src/StellarProvider.ts
@@ -9,6 +9,7 @@ import {
   type TokenAmount,
 } from '@lifi/sdk'
 import { Networks, StrKey } from '@stellar/stellar-sdk'
+import { getStellarAccountReserve } from './actions/getStellarAccountReserve.js'
 import { getStellarBalance } from './actions/getStellarBalance.js'
 import { resolveStellarAddress } from './actions/resolveStellarAddress.js'
 import { StellarStepExecutor } from './core/StellarStepExecutor.js'
@@ -51,6 +52,10 @@ export function StellarProvider(
         tokens,
         _options.networkPassphrase ?? DEFAULT_NETWORK_PASSPHRASE
       ),
+    getNativeReserve: (
+      client: SDKClient,
+      walletAddress: string
+    ): Promise<bigint> => getStellarAccountReserve(client, walletAddress),
     async getStepExecutor(options: StepExecutorOptions): Promise<StepExecutor> {
       if (!_options.getWallet) {
         throw new ProviderError(

--- a/packages/sdk-provider-stellar/src/actions/getStellarAccountReserve.ts
+++ b/packages/sdk-provider-stellar/src/actions/getStellarAccountReserve.ts
@@ -1,0 +1,127 @@
+import { type SDKClient, withDedupe } from '@lifi/sdk'
+import { Keypair, xdr } from '@stellar/stellar-sdk'
+import { callStellarRpcsWithRetry } from '../client/getStellarRpc.js'
+
+/**
+ * Base reserve in stroops (0.5 XLM). A network-wide protocol parameter that has
+ * been 0.5 XLM since 2015 and can only change through a validator-voted network
+ * upgrade. It lives in the ledger header, which Stellar RPC does not expose, so
+ * it is pinned here rather than read per call.
+ */
+export const BASE_RESERVE_STROOPS = 5_000_000n
+
+/**
+ * Base reserves every account owes before its subentries are counted: one for
+ * the account entry itself plus one the protocol requires on top.
+ */
+const ACCOUNT_BASE_RESERVES = 2n
+
+/**
+ * One base reserve of headroom for the trustline a swap may open on the sender's
+ * behalf. `LiFi::internal_swap` calls `try_trust(sender)` on the destination
+ * token (CAP-73) before it swaps, so a route into an asset the sender does not
+ * yet hold adds a subentry *inside the transaction being checked* — the floor at
+ * execution time is one base reserve above the floor read here. The headroom is
+ * unconditional: which token a route ends in is not known at this point, and
+ * over-reserving 0.5 XLM only costs idle balance, whereas under-reserving fails
+ * the transaction in simulation.
+ */
+const TRUSTLINE_HEADROOM = 1n
+
+type Sponsorships = { numSponsoring: number; numSponsored: number }
+
+const NO_SPONSORSHIPS: Sponsorships = { numSponsoring: 0, numSponsored: 0 }
+
+/**
+ * Reads the `AccountEntryExtensionV1` arm of the `AccountEntry.ext()` union, or
+ * `undefined` when the account carries no extension (the common case). Guarding
+ * on the discriminant is required — `.v1()` throws on a v0 account.
+ */
+const readExtensionV1 = (
+  account: xdr.AccountEntry
+): xdr.AccountEntryExtensionV1 | undefined => {
+  const ext = account.ext()
+  return ext.switch() === 1 ? ext.v1() : undefined
+}
+
+/**
+ * Sponsorship counts off the v2 extension. A sponsored subentry is paid for by
+ * the sponsor, so it raises the sponsor's reserve and lowers the sponsoree's.
+ */
+const readSponsorships = (account: xdr.AccountEntry): Sponsorships => {
+  const v1 = readExtensionV1(account)
+  if (!v1) {
+    return NO_SPONSORSHIPS
+  }
+  const v1Ext = v1.ext()
+  if (v1Ext.switch() !== 2) {
+    return NO_SPONSORSHIPS
+  }
+  const v2 = v1Ext.v2()
+  return {
+    numSponsoring: v2.numSponsoring(),
+    numSponsored: v2.numSponsored(),
+  }
+}
+
+/**
+ * Native selling liabilities — XLM already committed to open offers on the
+ * classic order book, which the protocol locks on top of the reserve.
+ */
+const readSellingLiabilities = (account: xdr.AccountEntry): bigint => {
+  const v1 = readExtensionV1(account)
+  return v1 ? BigInt(v1.liabilities().selling().toString()) : 0n
+}
+
+/**
+ * The XLM an account must keep and therefore cannot send:
+ *
+ * `(2 + numSubEntries + numSponsoring - numSponsored) x baseReserve + sellingLiabilities`
+ *
+ * plus {@link TRUSTLINE_HEADROOM}.
+ *
+ * A transfer that would leave the account below this floor is rejected by the
+ * native Stellar Asset Contract with `Error(Contract, #10)` (`BalanceError`),
+ * which surfaces as an opaque simulation `HostError` rather than a balance
+ * error — hence checking it up front.
+ */
+const accountReserve = (account: xdr.AccountEntry): bigint => {
+  const { numSponsoring, numSponsored } = readSponsorships(account)
+  const reserves =
+    ACCOUNT_BASE_RESERVES +
+    BigInt(account.numSubEntries()) +
+    TRUSTLINE_HEADROOM +
+    BigInt(numSponsoring) -
+    BigInt(numSponsored)
+  const reserve =
+    reserves * BASE_RESERVE_STROOPS + readSellingLiabilities(account)
+  // A fully sponsored account can drive the subentry term negative.
+  return reserve > 0n ? reserve : 0n
+}
+
+/**
+ * Reads the native reserve a Stellar account cannot spend, in stroops, with
+ * room for the trustline a swap may open (see {@link TRUSTLINE_HEADROOM}).
+ *
+ * Returns `0n` for an account with no ledger entry: an unfunded account holds
+ * nothing to protect, and every other check (balance, sequence number) fails on
+ * its own terms.
+ */
+export const getStellarAccountReserve = async (
+  client: SDKClient,
+  walletAddress: string
+): Promise<bigint> =>
+  withDedupe(
+    () =>
+      callStellarRpcsWithRetry(client, async (server) => {
+        const ledgerKey = xdr.LedgerKey.account(
+          new xdr.LedgerKeyAccount({
+            accountId: Keypair.fromPublicKey(walletAddress).xdrAccountId(),
+          })
+        )
+        const { entries } = await server.getLedgerEntries(ledgerKey)
+        const entry = entries.at(0)
+        return entry ? accountReserve(entry.val.account()) : 0n
+      }),
+    { id: `${getStellarAccountReserve.name}.${walletAddress}` }
+  )

--- a/packages/sdk-provider-stellar/src/actions/getStellarAccountReserve.unit.spec.ts
+++ b/packages/sdk-provider-stellar/src/actions/getStellarAccountReserve.unit.spec.ts
@@ -1,0 +1,143 @@
+import type { SDKClient } from '@lifi/sdk'
+import { Keypair, StrKey, xdr } from '@stellar/stellar-sdk'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const getLedgerEntries = vi.fn()
+
+vi.mock('../client/getStellarRpc.js', () => ({
+  callStellarRpcsWithRetry: (
+    _client: SDKClient,
+    fn: (server: {
+      getLedgerEntries: typeof getLedgerEntries
+    }) => Promise<unknown>
+  ) => fn({ getLedgerEntries }),
+}))
+
+import {
+  BASE_RESERVE_STROOPS,
+  getStellarAccountReserve,
+} from './getStellarAccountReserve.js'
+
+const ACCOUNT = Keypair.random().publicKey()
+const client = {} as SDKClient
+
+type EntryOptions = {
+  numSubEntries?: number
+  sponsorships?: { numSponsoring: number; numSponsored: number }
+  sellingLiabilities?: string
+}
+
+/**
+ * Builds a real `AccountEntry`. Without sponsorships or liabilities the entry
+ * carries the v0 (no-ext) discriminant — the common case, which exercises the
+ * zero defaults; otherwise the V1 → V2 ext chain is populated.
+ */
+const accountEntry = (options: EntryOptions = {}): xdr.LedgerEntryData => {
+  const needsExt =
+    options.sponsorships !== undefined ||
+    options.sellingLiabilities !== undefined
+  const ext = needsExt
+    ? new xdr.AccountEntryExt(
+        1,
+        new xdr.AccountEntryExtensionV1({
+          liabilities: new xdr.Liabilities({
+            buying: xdr.Int64.fromString('0'),
+            selling: xdr.Int64.fromString(options.sellingLiabilities ?? '0'),
+          }),
+          ext: new xdr.AccountEntryExtensionV1Ext(
+            2,
+            new xdr.AccountEntryExtensionV2({
+              numSponsored: options.sponsorships?.numSponsored ?? 0,
+              numSponsoring: options.sponsorships?.numSponsoring ?? 0,
+              signerSponsoringIDs: [],
+              ext: new xdr.AccountEntryExtensionV2Ext(0),
+            })
+          ),
+        })
+      )
+    : new xdr.AccountEntryExt(0)
+  return xdr.LedgerEntryData.account(
+    new xdr.AccountEntry({
+      accountId: Keypair.fromPublicKey(ACCOUNT).xdrAccountId(),
+      balance: xdr.Int64.fromString('120121714'),
+      seqNum: xdr.Int64.fromString('1'),
+      numSubEntries: options.numSubEntries ?? 0,
+      inflationDest: null,
+      flags: 0,
+      homeDomain: '',
+      thresholds: Buffer.from([1, 0, 0, 0]),
+      signers: [],
+      ext,
+    })
+  )
+}
+
+const mockEntry = (options?: EntryOptions): void => {
+  getLedgerEntries.mockResolvedValue({
+    latestLedger: 100,
+    entries: [{ key: 'ACC_KEY', val: accountEntry(options) }],
+  })
+}
+
+beforeEach(() => {
+  getLedgerEntries.mockReset()
+})
+
+describe('getStellarAccountReserve', () => {
+  it('reads the account entry of the given wallet', async () => {
+    mockEntry()
+    await getStellarAccountReserve(client, ACCOUNT)
+    const key: xdr.LedgerKey = getLedgerEntries.mock.calls[0][0]
+    expect(
+      StrKey.encodeEd25519PublicKey(key.account().accountId().ed25519())
+    ).toBe(ACCOUNT)
+  })
+
+  it('charges two base reserves plus trustline headroom for a bare account', async () => {
+    // The reported account: no subentries, so it must keep 1 XLM at rest — and
+    // 1.5 XLM through a swap, which is the floor its simulation reported.
+    mockEntry({ numSubEntries: 0 })
+    expect(await getStellarAccountReserve(client, ACCOUNT)).toBe(
+      3n * BASE_RESERVE_STROOPS
+    )
+  })
+
+  it('charges one base reserve per subentry', async () => {
+    mockEntry({ numSubEntries: 1 })
+    expect(await getStellarAccountReserve(client, ACCOUNT)).toBe(20_000_000n)
+  })
+
+  it('adds sponsored-away subentries to the sponsor and removes them from the sponsoree', async () => {
+    mockEntry({
+      numSubEntries: 1,
+      sponsorships: { numSponsoring: 2, numSponsored: 1 },
+    })
+    // 2 + 1 subentry + 1 headroom + 2 sponsoring - 1 sponsored = 5 base reserves
+    expect(await getStellarAccountReserve(client, ACCOUNT)).toBe(25_000_000n)
+  })
+
+  it('locks native selling liabilities on top of the reserve', async () => {
+    mockEntry({ numSubEntries: 1, sellingLiabilities: '5000000' })
+    expect(await getStellarAccountReserve(client, ACCOUNT)).toBe(25_000_000n)
+  })
+
+  it('never returns a negative reserve for a fully sponsored account', async () => {
+    mockEntry({
+      numSubEntries: 0,
+      sponsorships: { numSponsoring: 0, numSponsored: 5 },
+    })
+    expect(await getStellarAccountReserve(client, ACCOUNT)).toBe(0n)
+  })
+
+  it('returns zero when the account has no ledger entry', async () => {
+    getLedgerEntries.mockResolvedValue({ latestLedger: 100, entries: [] })
+    expect(await getStellarAccountReserve(client, ACCOUNT)).toBe(0n)
+  })
+
+  it('propagates a failed read so callers can retry it', async () => {
+    getLedgerEntries.mockRejectedValue(new Error('rpc down'))
+    await expect(getStellarAccountReserve(client, ACCOUNT)).rejects.toThrow(
+      'rpc down'
+    )
+  })
+})

--- a/packages/sdk/src/core/tasks/helpers/checkBalance.ts
+++ b/packages/sdk/src/core/tasks/helpers/checkBalance.ts
@@ -18,6 +18,7 @@ type Requirement = {
   sourcePart: bigint // step.action.fromAmount
   gasPart: bigint // step.estimate.gasCosts in this token
   feePart: bigint // non-included step.estimate.feeCosts in this token
+  reservePart: bigint // provider.getNativeReserve — unspendable, never trimmed
 }
 
 export type CheckBalanceOptions = {
@@ -34,10 +35,12 @@ export type CheckBalanceOptions = {
 /**
  * Verifies that the wallet holds enough of every token required to execute
  * the step on its source chain — the source-token amount, any gas costs, and
- * any non-included fee costs. Reads all balances in one batched provider
- * call, retries within a bounded budget to absorb transient RPC failures and
- * post-confirmation propagation lag, and applies slippage to the source-token
- * portion only as a last resort (overhead is never trimmed).
+ * any non-included fee costs. On chains whose native token carries an
+ * unspendable floor (`provider.getNativeReserve`, e.g. the Stellar account
+ * reserve) that floor is required on top. Reads all balances in one batched
+ * provider call, retries within a bounded budget to absorb transient RPC
+ * failures and post-confirmation propagation lag, and applies slippage to the
+ * source-token portion only as a last resort (overhead is never trimmed).
  *
  * Throws BalanceError("The balance is too low.") on a genuine shortfall, or
  * BalanceError("Could not read wallet balance.") if the balance can't be read
@@ -67,6 +70,7 @@ export const checkBalance = async (
       sourcePart: 0n,
       gasPart: 0n,
       feePart: 0n,
+      reservePart: 0n,
     }
     if (bucket === 'source') {
       req.sourcePart += amount
@@ -89,7 +93,7 @@ export const checkBalance = async (
   }
 
   const reservedOverhead = (r: Requirement): bigint =>
-    r.feePart + (walletPaysGas ? r.gasPart : 0n)
+    r.feePart + (walletPaysGas ? r.gasPart : 0n) + r.reservePart
   const need = (r: Requirement): bigint => r.sourcePart + reservedOverhead(r)
 
   // Drop pure-gas entries when `walletPaysGas` is false (e.g. native ETH
@@ -113,6 +117,17 @@ export const checkBalance = async (
 
   const reqs = Array.from(requirements.values())
   const tokens = reqs.map((r) => r.token)
+  // The reserve is a property of the account, not of the step, so it only
+  // matters when the step spends the native token — read it alongside the
+  // balances so it shares their retry budget and error handling. Requirements
+  // are already pruned, so no entry exists here purely because of a reserve.
+  const nativeRequirement = requirements.get(
+    fromChain.nativeToken.address.toLowerCase()
+  )
+  const readNativeReserve = (): Promise<bigint> =>
+    nativeRequirement && provider.getNativeReserve
+      ? provider.getNativeReserve(client, walletAddress)
+      : Promise.resolve(0n)
   const slippage = step.action.slippage ?? 0
   const slippageScaled = BigInt(
     Math.floor((1 - slippage) * Number(SLIPPAGE_PRECISION))
@@ -125,7 +140,14 @@ export const checkBalance = async (
 
         let balances: TokenAmount[]
         try {
-          balances = await provider.getBalance(client, walletAddress, tokens)
+          const [fetchedBalances, nativeReserve] = await Promise.all([
+            provider.getBalance(client, walletAddress, tokens),
+            readNativeReserve(),
+          ])
+          balances = fetchedBalances
+          if (nativeRequirement) {
+            nativeRequirement.reservePart = nativeReserve
+          }
         } catch (error) {
           if (isFinal) {
             throw new BalanceError(
@@ -158,7 +180,7 @@ export const checkBalance = async (
 
         // Final-attempt slippage rescue: only when the sole shortfall is
         // the source-token portion. Trim source to (balance − reserved
-        // overhead) so the overhead reserve is preserved.
+        // overhead) so gas, fees and any native reserve stay untouched.
         if (
           isFinal &&
           unknown.length === 0 &&
@@ -194,6 +216,13 @@ export const checkBalance = async (
             const needed = formatUnits(need(req), req.token.decimals)
             const current = formatUnits(have, req.token.decimals)
             const symbol = req.token.symbol
+            // A reserve shortfall is not a plain shortfall: the wallet may well
+            // hold the amount it is trying to send, just not on top of a floor
+            // the chain forbids it from spending.
+            if (req.reservePart > 0n) {
+              const reserve = formatUnits(req.reservePart, req.token.decimals)
+              return `Your ${symbol} balance is too low: ${needed} ${symbol} is required, including the ${reserve} ${symbol} reserve your account has to keep, but your wallet only holds ${current} ${symbol}.`
+            }
             // The "fees" branch covers pure-overhead tokens; with
             // walletPaysGas=false, gas is excluded from `need(req)` so it
             // only fires for genuine fee shortfalls.

--- a/packages/sdk/src/core/tasks/helpers/checkBalance.unit.spec.ts
+++ b/packages/sdk/src/core/tasks/helpers/checkBalance.unit.spec.ts
@@ -39,6 +39,17 @@ const NATIVE_MATIC: Token = {
   priceUSD: '0',
 }
 
+// Stellar's native XLM, addressed by its Stellar-Asset-Contract C-address:
+// a non-EVM, non-lowercase native address with 7 decimals.
+const NATIVE_XLM: Token = {
+  chainId: SOURCE_CHAIN,
+  address: 'CAS3J7GYLGXMF6TDJBBYYSE3HQ6BBSMLNUQ34T6TZMYMW2EVH34XOWMA',
+  symbol: 'XLM',
+  decimals: 7,
+  name: 'Stellar Lumens',
+  priceUSD: '0',
+}
+
 const WALLET = '0xWalletAddress'
 
 type ProviderResultMap = { [address: string]: bigint | undefined }
@@ -46,8 +57,16 @@ type AttemptScript = ProviderResultMap | 'reject'
 
 const buildClient = (
   attempts: AttemptScript[],
-  chainOverrides: { nonStandardNativeDecimals?: boolean } = {}
-): { client: SDKClient; getBalance: ReturnType<typeof vi.fn> } => {
+  chainOverrides: {
+    nonStandardNativeDecimals?: boolean
+    nativeTokenAddress?: string
+  } = {},
+  nativeReserve?: bigint | 'reject'
+): {
+  client: SDKClient
+  getBalance: ReturnType<typeof vi.fn>
+  getNativeReserve: ReturnType<typeof vi.fn>
+} => {
   let lastScript: AttemptScript = attempts[attempts.length - 1] ?? {}
   const getBalance = vi.fn(async (_client, _wallet, tokens: Token[]) => {
     const next = attempts.shift()
@@ -67,12 +86,22 @@ const buildClient = (
     })
   })
 
+  const getNativeReserve = vi.fn(async () => {
+    if (nativeReserve === 'reject') {
+      throw new Error('reserve read failed')
+    }
+    return nativeReserve ?? 0n
+  })
+
   const provider: SDKProvider = {
     type: 'EVM' as any,
     isAddress: (addr: string) => addr === WALLET,
     resolveAddress: vi.fn(),
     getStepExecutor: vi.fn(),
     getBalance,
+    // Only chains with an unspendable floor implement this; omitting it must
+    // leave every other chain's behavior untouched.
+    ...(nativeReserve === undefined ? {} : { getNativeReserve }),
   }
 
   const client = {
@@ -81,10 +110,13 @@ const buildClient = (
     getChainById: vi.fn(async (chainId: number) => ({
       id: chainId,
       nonStandardNativeDecimals: chainOverrides.nonStandardNativeDecimals,
+      nativeToken: {
+        address: chainOverrides.nativeTokenAddress ?? NATIVE_ETH.address,
+      },
     })),
   } as unknown as SDKClient
 
-  return { client, getBalance }
+  return { client, getBalance, getNativeReserve }
 }
 
 const buildStep = (overrides: Partial<LiFiStep['action']> = {}): LiFiStep => {
@@ -657,5 +689,114 @@ describe('checkBalance — RPC failures', () => {
       checkBalance(client, WALLET, buildStep())
     ).resolves.toBeUndefined()
     expect(getBalance).toHaveBeenCalledTimes(2)
+  })
+})
+
+describe('checkBalance — native reserve (provider.getNativeReserve)', () => {
+  // Stellar's account reserve: (2 + subentries) x 0.5 XLM, with one trustline.
+  const RESERVE = 15_000_000n
+  const BALANCE = 120_121_714n // 12.0121714 XLM
+
+  const buildStellarClient = (
+    balance: bigint,
+    reserve: bigint | 'reject' = RESERVE,
+    attempts = 6
+  ) =>
+    buildClient(
+      Array(attempts).fill({ [NATIVE_XLM.address.toLowerCase()]: balance }),
+      { nativeTokenAddress: NATIVE_XLM.address },
+      reserve
+    )
+
+  const buildStellarStep = (fromAmount: string, slippage = 0) =>
+    buildStep({
+      fromToken: NATIVE_XLM,
+      toToken: NATIVE_XLM,
+      fromAmount,
+      slippage,
+    })
+
+  it('rejects a native send that would break into the reserve', async () => {
+    // The reported failure: sending the whole balance minus 200 stroops leaves
+    // 200 stroops against a 1.5 XLM floor, which the native SAC rejects with
+    // Error(Contract, #10) at simulation time.
+    const { client } = buildStellarClient(BALANCE)
+    await expect(
+      checkBalance(client, WALLET, buildStellarStep('120121514'))
+    ).rejects.toMatchObject({
+      code: LiFiErrorCode.BalanceError,
+      message: 'The balance is too low.',
+      cause: {
+        message: expect.stringContaining(
+          '1.5 XLM reserve your account has to keep'
+        ),
+      },
+    })
+  })
+
+  it('passes when the balance covers the amount on top of the reserve', async () => {
+    const { client } = buildStellarClient(BALANCE)
+    await expect(
+      checkBalance(client, WALLET, buildStellarStep('105121714'))
+    ).resolves.toBeUndefined()
+  })
+
+  it('preserves exactly the reserve when trimming by slippage', async () => {
+    const step = buildStellarStep('110000000', 0.05)
+    // minAcceptable = 110000000 * 0.95 + 15000000 = 119500000 <= 120121714,
+    // so the source amount is trimmed to balance - reserve.
+    const { client } = buildStellarClient(BALANCE)
+    await expect(checkBalance(client, WALLET, step)).resolves.toBeUndefined()
+    expect(step.action.fromAmount).toBe(String(BALANCE - RESERVE))
+  })
+
+  it('requires the reserve on top of gas when the source token is not native', async () => {
+    const step = buildStep()
+    step.estimate!.gasCosts = [
+      {
+        type: 'SUM',
+        price: '0',
+        estimate: '0',
+        limit: '0',
+        amount: '10000', // 0.001 XLM standard fee
+        amountUSD: '0',
+        token: NATIVE_XLM,
+      },
+    ] as any
+    // 1 XLM covers the fee many times over but not the 1.5 XLM reserve.
+    const { client } = buildClient(
+      Array(6).fill({
+        [USDC.address.toLowerCase()]: 1_000_000n,
+        [NATIVE_XLM.address.toLowerCase()]: 10_000_000n,
+      }),
+      { nativeTokenAddress: NATIVE_XLM.address },
+      RESERVE
+    )
+    await expect(checkBalance(client, WALLET, step)).rejects.toMatchObject({
+      code: LiFiErrorCode.BalanceError,
+      message: 'The balance is too low.',
+    })
+  })
+
+  it('does not read the reserve when no native requirement exists', async () => {
+    const { client, getNativeReserve } = buildClient(
+      [{ [USDC.address.toLowerCase()]: 1_000_000n }],
+      { nativeTokenAddress: NATIVE_XLM.address },
+      RESERVE
+    )
+    await expect(
+      checkBalance(client, WALLET, buildStep())
+    ).resolves.toBeUndefined()
+    expect(getNativeReserve).not.toHaveBeenCalled()
+  })
+
+  it('throws "Could not read wallet balance" when the reserve read fails', async () => {
+    const { client } = buildStellarClient(BALANCE, 'reject')
+    await expect(
+      checkBalance(client, WALLET, buildStellarStep('1000000'))
+    ).rejects.toMatchObject({
+      code: LiFiErrorCode.BalanceError,
+      message: 'Could not read wallet balance.',
+    })
   })
 })

--- a/packages/sdk/src/types/core.ts
+++ b/packages/sdk/src/types/core.ts
@@ -60,6 +60,13 @@ export interface SDKProvider {
     walletAddress: string,
     tokens: Token[]
   ): Promise<TokenAmount[]>
+  /**
+   * Native-token amount the wallet holds but is not allowed to spend, in the
+   * native token's smallest unit — e.g. the Stellar account reserve, which
+   * every classic account must stay above. Optional: chains with no such floor
+   * omit it and callers treat the reserve as `0n`.
+   */
+  getNativeReserve?(client: SDKClient, walletAddress: string): Promise<bigint>
 }
 
 export interface SDKClient {


### PR DESCRIPTION
## Which Linear task is linked to this PR?

None yet — this came out of a reported mainnet swap failure. Happy to attach one.

## Why was it implemented this way?

A Stellar account may not drop below its minimum balance:

```
(2 + numSubEntries + numSponsoring - numSponsored) x baseReserve + native selling liabilities
```

Spending into that floor makes the native Stellar Asset Contract reject the `transfer` with `Error(Contract, #10)` (`BalanceError`). Because it fails inside a Soroban invocation, the user sees an opaque simulation `HostError` with a 20-event diagnostic dump rather than a balance error — the reported case was a max XLM swap that left 200 stroops against a 1.5 XLM floor.

Nothing in the SDK modelled this. `getStellarBalance` reads the raw SAC `balance()`, which for native XLM includes the reserve, so `checkBalance` saw a sufficient balance and passed. Worse, its final-attempt slippage rescue rewrote `fromAmount` to `have - reserved`, i.e. deliberately drained the account to zero — manufacturing the failure even from a safe user input.

**Why an optional `SDKProvider` method.** `getNativeReserve?(client, walletAddress)` is opt-in, so chains without an unspendable floor are untouched (no extra call, no behavior change) and any future chain with one — Solana's rent-exempt minimum is the same shape — implements the same hook. The alternative, a `CheckBalanceOptions` field plus a `StellarCheckBalanceTask` subclass, needed a new task per ecosystem and left the generic `CheckBalanceTask` unaware of the reserve, so the slippage rescue would still have trimmed into it.

**Why it folds into `reservedOverhead`.** That one helper feeds the sufficiency comparison, the "never trim overhead by slippage" rule, and the rescue's floor. Adding `reservePart` there fixes all three at once: the shortfall is now reported up front, and the rescue trims to `balance - gas - fees - reserve` instead of to zero. The reserve is read alongside the balances inside the retry loop, so it shares the existing 6-attempt backoff and both `BalanceError` paths, and it is only read when a step actually spends the native token.

**Why a flat trustline headroom.** `LiFi::internal_swap` calls `try_trust(&sender)` on the destination token (CAP-73) before swapping, so a route into an asset the sender does not yet hold **adds a subentry inside the transaction being checked** — the floor at execution time is one base reserve above the floor read beforehand. The reported account has `subentry_count: 0`, so its at-rest floor is 1.0 XLM while its simulation reported 1.5 XLM; without headroom a Max amount would leave 1.0 XLM and still fail on any first-time destination token. Which token a route ends in is not known at the point of the read, and over-reserving 0.5 XLM only idles balance whereas under-reserving fails the transaction, so the headroom is unconditional. An exact answer would need the destination token threaded into the read plus a trustline probe per quote; a follow-up option is for the API to report it, since the backend already resolves trustline status.

`baseReserve` is pinned at 0.5 XLM rather than read per call: it lives in the ledger header, which Stellar RPC does not expose, and changing it requires a validator-voted network upgrade (unchanged since 2015).

## Visual showcase (Screenshots or Videos)

No UI. Verified against mainnet with the account from the report — the computed reserve is `15000000` stroops, byte-identical to the floor its own failing simulation named:

```
["resulting balance is not within the allowed range", 15000000, 200, 9223372036854775807]
```

Cross-checked against Horizon: `subentry_count: 0`, no sponsorships, no selling liabilities.

## Checklist before requesting a review

- [x] I have performed a self-review and testing of my code.
- [x] This pull request is focused and addresses a single problem.
- [ ] If this PR modifies the SDK API or adds new features that require documentation, I have updated the documentation in the [public-docs](https://github.com/lifinance/public-docs) repository.

The API change is one optional method on `SDKProvider`, which only matters to someone implementing a custom provider — leaving the docs box for a reviewer to call.

**Tests:** 14 new unit tests — 8 covering the reserve computation (bare account, per-subentry, sponsorships both directions, selling liabilities, negative clamp, missing account, read failure) against real `AccountEntry` XDR, and 6 covering `checkBalance` (native shortfall with the reserve message, sufficient balance, slippage trimming that preserves exactly the reserve, reserve required on top of gas when the source token is not native, no read when no native requirement exists, and read failure).
