### PR TITLE
chore(test): report unhandled rejections instead of suppressing them repo-wide

### DIFF
--- a/packages/sdk-provider-bitcoin/package.json
+++ b/packages/sdk-provider-bitcoin/package.json
@@ -34,7 +34,7 @@
     "build:version": "node ../../scripts/version.js",
     "clean": "rm -rf dist",
     "coverage": "vitest run --coverage",
-    "test": "vitest --run --dangerouslyIgnoreUnhandledErrors",
+    "test": "vitest --run",
     "test:cov": "pnpm test --coverage",
     "test:unit": "pnpm test .unit.spec.ts --passWithNoTests",
     "check:types": "tsc --noEmit && tsc -p tsconfig.spec.json --noEmit",

--- a/packages/sdk-provider-ethereum/package.json
+++ b/packages/sdk-provider-ethereum/package.json
@@ -34,7 +34,7 @@
     "build:version": "node ../../scripts/version.js",
     "clean": "rm -rf dist",
     "coverage": "vitest run --coverage",
-    "test": "vitest --run --dangerouslyIgnoreUnhandledErrors",
+    "test": "vitest --run",
     "test:cov": "pnpm test --coverage",
     "test:unit": "pnpm test .unit.spec.ts --passWithNoTests",
     "check:types": "tsc --noEmit && tsc -p tsconfig.spec.json --noEmit",

--- a/packages/sdk-provider-stellar/package.json
+++ b/packages/sdk-provider-stellar/package.json
@@ -34,7 +34,7 @@
     "build:version": "node ../../scripts/version.js",
     "clean": "rm -rf dist",
     "coverage": "vitest run --coverage",
-    "test": "vitest --run --dangerouslyIgnoreUnhandledErrors",
+    "test": "vitest --run",
     "test:cov": "pnpm test --coverage",
     "test:unit": "pnpm test .unit.spec.ts --passWithNoTests",
     "check:types": "tsc --noEmit && tsc -p tsconfig.spec.json --noEmit",

--- a/packages/sdk-provider-sui/package.json
+++ b/packages/sdk-provider-sui/package.json
@@ -34,7 +34,7 @@
     "build:version": "node ../../scripts/version.js",
     "clean": "rm -rf dist",
     "coverage": "vitest run --coverage",
-    "test": "vitest --run --dangerouslyIgnoreUnhandledErrors",
+    "test": "vitest --run",
     "test:cov": "pnpm test --coverage",
     "test:unit": "pnpm test .unit.spec.ts --passWithNoTests",
     "check:types": "tsc --noEmit && tsc -p tsconfig.spec.json --noEmit",

--- a/packages/sdk-provider-tron/package.json
+++ b/packages/sdk-provider-tron/package.json
@@ -34,7 +34,7 @@
     "build:version": "node ../../scripts/version.js",
     "clean": "rm -rf dist",
     "coverage": "vitest run --coverage",
-    "test": "vitest --run --dangerouslyIgnoreUnhandledErrors",
+    "test": "vitest --run",
     "test:cov": "pnpm test --coverage",
     "test:unit": "pnpm test .unit.spec.ts --passWithNoTests",
     "check:types": "tsc --noEmit && tsc -p tsconfig.spec.json --noEmit",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -34,7 +34,7 @@
     "build:version": "node ../../scripts/version.js",
     "clean": "rm -rf dist",
     "coverage": "vitest run --coverage",
-    "test": "vitest --run --dangerouslyIgnoreUnhandledErrors",
+    "test": "vitest --run",
     "test:cov": "pnpm test --coverage",
     "test:unit": "pnpm test .unit.spec.ts --passWithNoTests",
     "check:types": "tsc --noEmit && tsc -p tsconfig.spec.json --noEmit",

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -4,7 +4,9 @@ import { defineConfig } from 'vitest/config'
 export default defineConfig({
   // plugins: [tsconfigPaths() as any],
   test: {
-    dangerouslyIgnoreUnhandledErrors: true,
+    // Deliberately absent: `dangerouslyIgnoreUnhandledErrors`. Suppressing it
+    // repo-wide hid the one failure class detached promises introduce - a
+    // leaked rejection was reported and the run still exited 0.
     coverage: {
       provider: 'v8',
     },


### PR DESCRIPTION
## Which Linear task is linked to this PR?

None — follow-up from the review of #448, which found the same defect in
`sdk-provider-solana` and fixes it there.

## Why was it implemented this way?

Every package ran `vitest` with `--dangerouslyIgnoreUnhandledErrors`, and the root
`vitest.config.ts` set it as well. A leaked promise rejection was therefore printed and the
run still exited **0** — so CI could not see the one failure class detached promises
introduce.

Both suppressors had to go. The root config is read for a package run (tests run with
`cwd` = package dir via `pnpm -r --parallel test`), so removing only the CLI flag changes
nothing. Verified, not assumed: with a spec that leaks one rejection,

- after this change → exit **1**
- with the root setting temporarily restored → exit **0**

`packages/sdk-provider-solana` is deliberately untouched here. #448 removes its flag and
adds a package-level config for exactly this reason, and editing the same line on two
branches would only produce a conflict. `git merge-tree` confirms the two branches merge
cleanly.

**Alternative considered and rejected:** a package-level `vitest.config.ts` per package.
That replaces the root config rather than merging with it, so each one would have to
restate `coverage.provider`, and six copies would drift. Removing the root setting is one
edit and cannot drift.

**Follow-up, after this merges:** `packages/sdk-provider-solana/vitest.config.ts` becomes
redundant — an explicit `false` is the default once the root no longer sets `true` — and
can be deleted so Solana inherits the root config again. Not before, or #448 alone would
silently re-suppress Solana.

No changeset: test configuration only, no publishable source change.

## Visual showcase (Screenshots or Videos)

n/a

## Test plan

Nothing was hiding behind the flag. All six packages pass with the check on:

| package | result |
|---|---|
| `@lifi/sdk` | 478 passed, 10 skipped |
| `sdk-provider-bitcoin` | 15 passed |
| `sdk-provider-ethereum` | 137 passed |
| `sdk-provider-stellar` | 91 passed, 3 skipped |
| `sdk-provider-sui` | 13 passed |
| `sdk-provider-tron` | 36 passed |

- [x] `pnpm check` — 404 files, clean
- [x] `pnpm check:types` — 0 errors
- [x] `pnpm knip:check` — clean

## Checklist before requesting a review

- [x] I have performed a self-review and testing of my code.
- [x] This pull request is focused and addresses a single problem.
- [x] If this PR modifies the SDK API or adds new features that require documentation, I have updated the documentation in the [public-docs](https://github.com/lifinance/public-docs) repository. — n/a, test configuration only
