### PR TITLE
chore: widen @lifi/types to a caret range

### DIFF
--- a/.changeset/lifi-types-caret.md
+++ b/.changeset/lifi-types-caret.md
@@ -1,0 +1,13 @@
+---
+'@lifi/sdk': minor
+---
+
+Widen the `@lifi/types` dependency from the exact pin `18.2.0` to `^18.3.0`.
+
+The exact pin forced a second copy of `@lifi/types` into any tree that also used
+`@lifi/perps-sdk`, which pins exactly too. Two exact pins on different versions can
+never share a resolution. Carets on both sides let the package manager settle on one
+version, and remove the need for the two packages to bump in lockstep.
+
+`@lifi/sdk` re-exports `@lifi/types` in full, so the change is a minor rather than a
+patch.

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -44,7 +44,7 @@
     "watch": "tsdown --watch"
   },
   "dependencies": {
-    "@lifi/types": "18.2.0"
+    "@lifi/types": "^18.3.0"
   },
   "devDependencies": {
     "@lifi/data-types": "^7.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -55,8 +55,8 @@ importers:
   packages/sdk:
     dependencies:
       '@lifi/types':
-        specifier: 18.2.0
-        version: 18.2.0
+        specifier: ^18.3.0
+        version: 18.3.0
     devDependencies:
       '@lifi/data-types':
         specifier: ^7.0.1
@@ -643,6 +643,9 @@ packages:
 
   '@lifi/types@18.2.0':
     resolution: {integrity: sha512-ap0p93xeLAMAnSQfGaeV6Gb2SLcgmyUOXav9w7fBHIcDK87Oio+On7WF4syknpwBd/JfbTV/gpH+Yfs2biQJcA==}
+
+  '@lifi/types@18.3.0':
+    resolution: {integrity: sha512-Qe7mIQ48P38FWguor4KNd5aFxFZqQElAt3T36Ft8X/vbrJLVEfNIOXgwBlvvxX5Fe1JADpu14MrS53mNVFKUbQ==}
 
   '@manypkg/find-root@3.1.0':
     resolution: {integrity: sha512-BcSqCyKhBVZ5YkSzOiheMCV41kqAFptW6xGqYSTjkVTl9XQpr+pqHhwgGCOHQtjDCv7Is6EFyA14Sm5GVbVABA==}
@@ -3981,6 +3984,8 @@ snapshots:
       '@lifi/types': 18.2.0
 
   '@lifi/types@18.2.0': {}
+
+  '@lifi/types@18.3.0': {}
 
   '@manypkg/find-root@3.1.0':
     dependencies:


### PR DESCRIPTION
Widens `@lifi/types` in `packages/sdk` from the exact pin `18.2.0` to `^18.3.0`.

## Why the exact pin was a problem

`@lifi/sdk` pinned `@lifi/types` to exactly `18.2.0`. `@lifi/perps-sdk` pins exactly
too. **Two exact pins on different versions can never share a resolution**, so any app
depending on both carried two copies of `@lifi/types` — and no consumer-side override
could fix it, because overriding either one would violate the other's declared pin.

Caret ranges on both sides let the package manager settle on a single version, and
remove the requirement that the two packages bump in lockstep forever.

The matching change to perps-sdk is **lifinance/perps-sdk#392**. Both are needed:
loosening only one side still leaves the other's exact pin holding a second copy.

## Why `minor` and not `patch`

`packages/sdk/src/index.ts` does `export * from '@lifi/types'`, so the whole of
`@lifi/types` is part of this package's public surface. Widening which versions can
appear there is a minor, not a patch.

## One duplicate this does not fix, and why it does not matter

After this change, this repo's own lockfile still resolves **both** `18.2.0` and
`18.3.0`. The second copy comes from `@lifi/data-types@7.0.1`, which also pins
`@lifi/types` exactly at `18.2.0` — and `7.0.1` is its latest release.

That one is confined to development: `@lifi/data-types` is a **devDependency** of the
sdk and provider packages, and it does not appear in `@lifi/sdk`'s published
`dependencies` (verified against the registry). So it never reaches a consumer tree.

Worth fixing separately in `@lifi/data-types` for tidiness, but it does not block the
consumer-facing dedup this PR delivers.

## Release ordering matters, and the floors must match

I measured every combination on a throwaway consumer (unpacked published tarballs with
patched manifests, so real range resolution is exercised), verified against
`node_modules/.pnpm` and `pnpm why`:

| @lifi/sdk | @lifi/perps-sdk | copies |
|---|---|---|
| exact `18.2.0` (today) | `^18.3.0` | 2 |
| `^18.2.0` | `^18.3.0` | 2 on a **warm** install — the old `18.2.0` still satisfies `^18.2.0` and survives |
| **`^18.3.0`** | **`^18.3.0`** | **1**, cold and warm |

Two consequences:

1. **This PR uses `^18.3.0`, not `^18.2.0`, deliberately.** A lower floor here leaves the
   stale `18.2.0` resolution valid on warm installs, so consumers keep two copies until
   someone runs `pnpm dedupe`. Equal floors invalidate the old resolution on both edges
   and force a single re-resolve.
2. **Keep the caret floors equal** across both packages on future bumps, or they silently
   re-duplicate.

perps-sdk#392 should not be *published* before this ships — on its own it resolves to two
copies, which is worse than the current state. Merging either is safe; the ordering
constraint is on release.

## Validation

| Check | Result |
|---|---|
| `check` (biome) | pass — 436 files |
| `check:types` | pass, all 7 packages |
| `check:circular-deps` | pass, no cycles |
| `knip:check` | pass |
| `build` | pass |
| `test` | **798 tests passing**, zero failures |

No code changes were needed — 18.3.0 is a drop-in for everything this package uses.
