### PR TITLE
chore: bump @stellar/stellar-sdk to 17.0.1

### DIFF
--- a/.changeset/stellar-sdk-17.md
+++ b/.changeset/stellar-sdk-17.md
@@ -4,21 +4,31 @@
 
 Bump `@stellar/stellar-sdk` from 16.2.0 to 17.0.1.
 
-v17 rebuilds the XDR namespace as a class based API and switches every
-byte returning API from `Buffer` to `Uint8Array`. Three call sites needed
-updating and the public API of this package is unchanged.
+v17 rebuilds the XDR namespace as a class based API and switches every byte
+returning API from `Buffer` to `Uint8Array`. The public API of this package is
+unchanged.
 
 `deriveTransactionHash` called `.toString('hex')` on the result of
 `transaction.hash()`. That is a `Uint8Array` now, whose `toString` ignores the
-argument and returns comma separated decimals, so the hash is built from the
-bytes directly. The helper still returns the same 64 character lowercase hex
-digest, verified against the raw digest for a signed transaction.
+argument and returns comma separated decimals, so the digest is built from the
+bytes instead. The helper still returns the same 64 character lowercase hex
+string, which `StellarSignAndExecuteTask.unit.spec.ts` asserts against an
+independently computed digest.
 
 `submitStellarTransaction` and `waitForStellarTransaction` read the failure
 reason through `result().switch().name`. The generated XDR classes expose
-`result` as a readonly field and carry a `type` discriminant, so both now read
-`result.type`. The variant names are unchanged, so error messages are the same.
+`result` as a readonly field with a `type` discriminant, so both read
+`result.type`. The variant names are unchanged, and a new test pins the failure
+variant into the error message.
 
-`toXDR` is deprecated in v17 in favour of `toXdr`, and still present as an
-alias, so nothing broke. All five call sites moved to `toXdr` anyway rather
-than leave deprecated calls behind.
+`toXDR` and `TransactionBuilder.fromXDR` are both deprecated in v17 in favour of
+`toXdr` and `fromXdr`, and both remain as aliases. All seven call sites moved to
+the new names.
+
+Two behaviour notes that need no code change here. v17 raises its Node floor to
+22.12.0, and CI runs Node 26. v17 also sends `useUpgradedAuth: true` on every
+simulation rather than omitting the key, which turns on CAP-71 address
+credentials. The two read paths simulate methods that need no authorization, and
+the approve path authorizes with the transaction source account, so a live
+mainnet simulation records `sorobanCredentialsSourceAccount` and the flag has no
+effect. Mainnet is on protocol 27, which activates CAP-71 in any case.

--- a/.changeset/stellar-sdk-17.md
+++ b/.changeset/stellar-sdk-17.md
@@ -1,0 +1,23 @@
+---
+'@lifi/sdk-provider-stellar': patch
+---
+
+Bump `@stellar/stellar-sdk` from 16.2.0 to 17.0.1.
+
+v17 rebuilds the XDR namespace as a class based API and switches every
+byte returning API from `Buffer` to `Uint8Array`. Three call sites needed
+updating and the public API of this package is unchanged.
+
+`deriveTransactionHash` called `.toString('hex')` on the result of
+`transaction.hash()`. That is a `Uint8Array` now, whose `toString` ignores the
+argument and returns comma separated decimals, so the hash is built from the
+bytes directly. The helper still returns the same 64 character lowercase hex
+digest, verified against the raw digest for a signed transaction.
+
+`submitStellarTransaction` and `waitForStellarTransaction` read the failure
+reason through `result().switch().name`. The generated XDR classes expose
+`result` as a readonly field and carry a `type` discriminant, so both now read
+`result.type`. The variant names are unchanged, so error messages are the same.
+
+`Transaction` still exposes `toXDR` alongside the new `toXdr`, so no call site
+needed renaming.

--- a/.changeset/stellar-sdk-17.md
+++ b/.changeset/stellar-sdk-17.md
@@ -19,5 +19,6 @@ reason through `result().switch().name`. The generated XDR classes expose
 `result` as a readonly field and carry a `type` discriminant, so both now read
 `result.type`. The variant names are unchanged, so error messages are the same.
 
-`Transaction` still exposes `toXDR` alongside the new `toXdr`, so no call site
-needed renaming.
+`toXDR` is deprecated in v17 in favour of `toXdr`, and still present as an
+alias, so nothing broke. All five call sites moved to `toXdr` anyway rather
+than leave deprecated calls behind.

--- a/packages/sdk-provider-stellar/package.json
+++ b/packages/sdk-provider-stellar/package.json
@@ -45,7 +45,7 @@
   },
   "dependencies": {
     "@lifi/sdk": "workspace:*",
-    "@stellar/stellar-sdk": "^16.2.0"
+    "@stellar/stellar-sdk": "^17.0.1"
   },
   "devDependencies": {
     "@lifi/data-types": "^7.0.1",

--- a/packages/sdk-provider-stellar/src/actions/getStellarBalance.int.spec.ts
+++ b/packages/sdk-provider-stellar/src/actions/getStellarBalance.int.spec.ts
@@ -13,11 +13,13 @@ const client = createClient({
   integrator: 'lifi-sdk',
 })
 
-// A well-known, long-lived mainnet account (the SDF public distribution
-// account). Only used as a read target — the assertions below hold for any
-// valid G-address, funded or not, so this test does not depend on a balance.
+// A live mainnet account, used only as a read target. The account needs a
+// trustline for every non-native asset the tests read, because a SAC balance
+// call on a missing trustline fails the simulation and degrades to an absent
+// amount rather than returning zero. This one holds XLM. Give it a USDC
+// trustline, or swap the address, before un-skipping the USDC case.
 const defaultWalletAddress =
-  'GCKFBEIYV2U22IO2AM6SVKMSAWTM3KOMSGYPWDLNCONJZLQGH2FQNBRW'
+  'GB3TRHIIJIP3L54672MTHWTS6M5I3STHOZ372PZAKC63H6VJ3C222HPP'
 
 const retryTimes = 2
 const timeout = 20000

--- a/packages/sdk-provider-stellar/src/core/tasks/StellarSetAllowanceTask.unit.spec.ts
+++ b/packages/sdk-provider-stellar/src/core/tasks/StellarSetAllowanceTask.unit.spec.ts
@@ -51,7 +51,10 @@ const signedApproveEnvelope = (): { xdr: string; hash: string } => {
     .setTimeout(300)
     .build()
   transaction.sign(keypair)
-  return { xdr: transaction.toXDR(), hash: transaction.hash().toString('hex') }
+  return {
+    xdr: transaction.toXDR(),
+    hash: Buffer.from(transaction.hash()).toString('hex'),
+  }
 }
 
 const makeContext = (overrides: Record<string, unknown> = {}) => {

--- a/packages/sdk-provider-stellar/src/core/tasks/StellarSetAllowanceTask.unit.spec.ts
+++ b/packages/sdk-provider-stellar/src/core/tasks/StellarSetAllowanceTask.unit.spec.ts
@@ -52,7 +52,7 @@ const signedApproveEnvelope = (): { xdr: string; hash: string } => {
     .build()
   transaction.sign(keypair)
   return {
-    xdr: transaction.toXDR(),
+    xdr: transaction.toXdr(),
     hash: Buffer.from(transaction.hash()).toString('hex'),
   }
 }

--- a/packages/sdk-provider-stellar/src/core/tasks/StellarSignAndExecuteTask.unit.spec.ts
+++ b/packages/sdk-provider-stellar/src/core/tasks/StellarSignAndExecuteTask.unit.spec.ts
@@ -94,7 +94,7 @@ describe('StellarSignAndExecuteTask', () => {
   it('derives the hash from the signed envelope rather than the submit response', async () => {
     const transaction = buildSignedTransaction()
     const expectedHash = Buffer.from(transaction.hash()).toString('hex')
-    const signedTxXdr = transaction.toXDR()
+    const signedTxXdr = transaction.toXdr()
     const { context, updateAction } = makeContext(signedTxXdr)
 
     const result = await new StellarSignAndExecuteTask().run(context)
@@ -118,7 +118,7 @@ describe('StellarSignAndExecuteTask', () => {
       order.push('submit')
       return 'network-hash'
     })
-    const { context } = makeContext(buildSignedTransaction().toXDR(), () =>
+    const { context } = makeContext(buildSignedTransaction().toXdr(), () =>
       order.push('updateAction')
     )
 
@@ -129,7 +129,7 @@ describe('StellarSignAndExecuteTask', () => {
 
   it('signs the payload returned by getTransactionRequestData', async () => {
     const { context, signTransaction } = makeContext(
-      buildSignedTransaction().toXDR()
+      buildSignedTransaction().toXdr()
     )
 
     await new StellarSignAndExecuteTask().run(context)

--- a/packages/sdk-provider-stellar/src/core/tasks/StellarSignAndExecuteTask.unit.spec.ts
+++ b/packages/sdk-provider-stellar/src/core/tasks/StellarSignAndExecuteTask.unit.spec.ts
@@ -93,7 +93,7 @@ describe('StellarSignAndExecuteTask', () => {
 
   it('derives the hash from the signed envelope rather than the submit response', async () => {
     const transaction = buildSignedTransaction()
-    const expectedHash = transaction.hash().toString('hex')
+    const expectedHash = Buffer.from(transaction.hash()).toString('hex')
     const signedTxXdr = transaction.toXDR()
     const { context, updateAction } = makeContext(signedTxXdr)
 

--- a/packages/sdk-provider-stellar/src/core/tasks/helpers/buildApproveTransaction.ts
+++ b/packages/sdk-provider-stellar/src/core/tasks/helpers/buildApproveTransaction.ts
@@ -58,5 +58,5 @@ export const buildApproveTransaction = async (
       .build()
 
     const prepared = await server.prepareTransaction(transaction)
-    return prepared.toXDR()
+    return prepared.toXdr()
   })

--- a/packages/sdk-provider-stellar/src/core/tasks/helpers/deriveTransactionHash.ts
+++ b/packages/sdk-provider-stellar/src/core/tasks/helpers/deriveTransactionHash.ts
@@ -11,7 +11,7 @@ export const deriveTransactionHash = (
   signedTxXdr: string,
   networkPassphrase: string
 ): string => {
-  const transaction = TransactionBuilder.fromXDR(
+  const transaction = TransactionBuilder.fromXdr(
     signedTxXdr,
     networkPassphrase
   ) as Transaction

--- a/packages/sdk-provider-stellar/src/core/tasks/helpers/deriveTransactionHash.ts
+++ b/packages/sdk-provider-stellar/src/core/tasks/helpers/deriveTransactionHash.ts
@@ -15,5 +15,7 @@ export const deriveTransactionHash = (
     signedTxXdr,
     networkPassphrase
   ) as Transaction
-  return transaction.hash().toString('hex')
+  return Array.from(transaction.hash(), (byte) =>
+    byte.toString(16).padStart(2, '0')
+  ).join('')
 }

--- a/packages/sdk-provider-stellar/src/core/tasks/helpers/submitStellarTransaction.ts
+++ b/packages/sdk-provider-stellar/src/core/tasks/helpers/submitStellarTransaction.ts
@@ -33,7 +33,7 @@ export const submitStellarTransaction = async (
   signedTxXdr: string,
   networkPassphrase: string
 ): Promise<string> => {
-  const transaction = TransactionBuilder.fromXDR(
+  const transaction = TransactionBuilder.fromXdr(
     signedTxXdr,
     networkPassphrase
   ) as Transaction

--- a/packages/sdk-provider-stellar/src/core/tasks/helpers/submitStellarTransaction.ts
+++ b/packages/sdk-provider-stellar/src/core/tasks/helpers/submitStellarTransaction.ts
@@ -54,7 +54,7 @@ export const submitStellarTransaction = async (
         throw new TransactionError(
           LiFiErrorCode.TransactionFailed,
           `Stellar transaction submission failed: ${
-            response.errorResult?.result().switch().name ?? response.status
+            response.errorResult?.result.type ?? response.status
           }`
         )
     }

--- a/packages/sdk-provider-stellar/src/core/tasks/helpers/submitStellarTransaction.unit.spec.ts
+++ b/packages/sdk-provider-stellar/src/core/tasks/helpers/submitStellarTransaction.unit.spec.ts
@@ -10,10 +10,10 @@ vi.mock('../../../client/getStellarRpc.js', () => ({
   ) => fn({ sendTransaction }),
 }))
 
-// `fromXDR` is the only runtime member this module uses; everything else it
+// `fromXdr` is the only runtime member this module uses; everything else it
 // imports from the SDK is a type and erases at build time.
 vi.mock('@stellar/stellar-sdk', () => ({
-  TransactionBuilder: { fromXDR: () => ({}) },
+  TransactionBuilder: { fromXdr: () => ({}) },
 }))
 
 const { submitStellarTransaction } = await import(
@@ -78,5 +78,18 @@ describe('submitStellarTransaction', () => {
       LiFiErrorCode.TransactionFailed
     )
     expect(sendTransaction).toHaveBeenCalledTimes(1)
+  })
+
+  it('names the failure variant from the error result', async () => {
+    sendTransaction.mockResolvedValue({
+      status: 'ERROR',
+      errorResult: { result: { type: 'txInsufficientBalance' } },
+    })
+
+    const thrown = await submit().catch((error: unknown) => error)
+
+    expect((thrown as TransactionError).message).toContain(
+      'txInsufficientBalance'
+    )
   })
 })

--- a/packages/sdk-provider-stellar/src/core/tasks/helpers/waitForStellarTransaction.ts
+++ b/packages/sdk-provider-stellar/src/core/tasks/helpers/waitForStellarTransaction.ts
@@ -49,7 +49,7 @@ export const waitForStellarTransaction = async (
         throw new TransactionError(
           LiFiErrorCode.TransactionFailed,
           `Stellar transaction ${transactionHash} failed: ${
-            response.resultXdr?.result().switch().name ?? 'unknown reason'
+            response.resultXdr?.result.type ?? 'unknown reason'
           }`
         )
       }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -191,8 +191,8 @@ importers:
         specifier: workspace:*
         version: link:../sdk
       '@stellar/stellar-sdk':
-        specifier: ^16.2.0
-        version: 16.2.0(debug@4.4.3(supports-color@7.2.0))(supports-color@7.2.0)
+        specifier: ^17.0.1
+        version: 17.0.1(debug@4.4.3(supports-color@7.2.0))(supports-color@7.2.0)
     devDependencies:
       '@lifi/data-types':
         specifier: ^7.0.1
@@ -567,6 +567,15 @@ packages:
 
   '@emnapi/wasi-threads@1.2.2':
     resolution: {integrity: sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==}
+
+  '@exodus/bytes@1.15.1':
+    resolution: {integrity: sha512-S6mL0yNB/Abt9Ei4tq8gDhcczc4S3+vQ4ra7vxnAf+YHC02srtqxKKZghx2Dq6p0e66THKwR6r8N6P95wEty7Q==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+    peerDependencies:
+      '@noble/hashes': ^1.8.0 || ^2.0.0
+    peerDependenciesMeta:
+      '@noble/hashes':
+        optional: true
 
   '@gql.tada/cli-utils@1.9.3':
     resolution: {integrity: sha512-P1TiXErpJwIi73sei5fzwGA/SOeCaIHFWFR4RdZPLwqxZzQN0T6MAUivzXBgKCORL67rvYnLaaPoWeqWq/61ug==}
@@ -1524,13 +1533,13 @@ packages:
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
 
-  '@stellar/js-xdr@4.0.0':
-    resolution: {integrity: sha512-+NmNa7Tk5BI5XFdy/6xGTqAN4J9a9KgCrCGhj2uEUTCBhLkch0M+QbKzNH8zEnejWe0p8w+0q5hUVX6L3OzoVA==}
-    engines: {node: '>=20.0.0', pnpm: '>=9.0.0'}
+  '@stellar/js-xdr@5.0.0':
+    resolution: {integrity: sha512-HBDNKnxr+ecdaEmbZ0mcKkirOF8tXXEbWSw34P3wT40Tn3g+u+cCH17xAWZymzscq8cojHB8340pR8QNVaD32w==}
+    engines: {node: '>=22.0.0', pnpm: '>=10.0.0'}
 
-  '@stellar/stellar-sdk@16.2.0':
-    resolution: {integrity: sha512-FV/Rm11QvrFzR5X9fIfb6Pg30KyYyrRkNezELGFmYDAYrzoPTjqo7vklnEPd2HEontzjJmZizWk8CjyIh5vp0w==}
-    engines: {node: '>=22.0.0'}
+  '@stellar/stellar-sdk@17.0.1':
+    resolution: {integrity: sha512-fsHHbzJ14N5Ttq5Qpz4AX0ytmPSLCzcy4XC3uIgSQz0cBkEgv0Zb4KE6tWEd3nDQUk/1qP8ZX9cRonIaUXO3Sw==}
+    engines: {node: '>=22.12.0'}
     hasBin: true
 
   '@tronweb3/tronwallet-abstract-adapter@1.2.0':
@@ -1564,6 +1573,9 @@ packages:
 
   '@types/estree@1.0.9':
     resolution: {integrity: sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==}
+
+  '@types/json-schema@7.0.15':
+    resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
 
   '@types/node@22.7.5':
     resolution: {integrity: sha512-jML7s2NAzMWc//QSJ1a3prpk78cOPchGvXJsC3C6R6PSMoooztvRVQEz89gmBTBY1SPMaqo5teB4uNHPdetShQ==}
@@ -2000,10 +2012,6 @@ packages:
   base-x@5.0.1:
     resolution: {integrity: sha512-M7uio8Zt++eg3jPj+rHMfCC+IuygQHHCOU+IYsVtik6FWjuYpVt/+MRKcgsAMHh8mMFAwnB+Bs+mTrFiXjMzKg==}
 
-  base32.js@0.1.0:
-    resolution: {integrity: sha512-n3TkB02ixgBOhTvANakDb4xaMXnYUVkNoRFJjQflcqMQhyEKxEHdj3E6N8t8sUQ0mjH/3/JxzlXuz3ul/J90pQ==}
-    engines: {node: '>=0.12.0'}
-
   base64-js@1.5.1:
     resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
 
@@ -2043,9 +2051,6 @@ packages:
 
   buffer@5.7.1:
     resolution: {integrity: sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==}
-
-  buffer@6.0.3:
-    resolution: {integrity: sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==}
 
   cac@7.0.0:
     resolution: {integrity: sha512-tixWYgm5ZoOD+3g6UTea91eow5z6AAHaho3g0V9CNSNb45gM8SmflpAc+GRd1InC4AqN/07Unrgp56Y94N9hJQ==}
@@ -3926,6 +3931,10 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
+  '@exodus/bytes@1.15.1(@noble/hashes@2.3.0)':
+    optionalDependencies:
+      '@noble/hashes': 2.3.0
+
   '@gql.tada/cli-utils@1.9.3(@0no-co/graphqlsp@1.17.5(graphql@17.0.2)(typescript@7.0.2))(graphql@17.0.2)(typescript@7.0.2)':
     dependencies:
       '@0no-co/graphqlsp': 1.17.5(graphql@17.0.2)(typescript@7.0.2)
@@ -4831,17 +4840,17 @@ snapshots:
 
   '@standard-schema/spec@1.1.0': {}
 
-  '@stellar/js-xdr@4.0.0': {}
+  '@stellar/js-xdr@5.0.0': {}
 
-  '@stellar/stellar-sdk@16.2.0(debug@4.4.3(supports-color@7.2.0))(supports-color@7.2.0)':
+  '@stellar/stellar-sdk@17.0.1(debug@4.4.3(supports-color@7.2.0))(supports-color@7.2.0)':
     dependencies:
+      '@exodus/bytes': 1.15.1(@noble/hashes@2.3.0)
       '@noble/ed25519': 3.1.0
       '@noble/hashes': 2.3.0
-      '@stellar/js-xdr': 4.0.0
+      '@stellar/js-xdr': 5.0.0
+      '@types/json-schema': 7.0.15
       axios: 1.19.0(debug@4.4.3(supports-color@7.2.0))(supports-color@7.2.0)
-      base32.js: 0.1.0
       bignumber.js: 11.1.5
-      buffer: 6.0.3
       commander: 14.0.3
       eventsource: 4.1.1
       feaxios: 0.0.23
@@ -4889,6 +4898,8 @@ snapshots:
   '@types/deep-eql@4.0.2': {}
 
   '@types/estree@1.0.9': {}
+
+  '@types/json-schema@7.0.15': {}
 
   '@types/node@22.7.5':
     dependencies:
@@ -5237,8 +5248,6 @@ snapshots:
 
   base-x@5.0.1: {}
 
-  base32.js@0.1.0: {}
-
   base64-js@1.5.1: {}
 
   bech32@2.0.0: {}
@@ -5288,11 +5297,6 @@ snapshots:
       bs58: 6.0.0
 
   buffer@5.7.1:
-    dependencies:
-      base64-js: 1.5.1
-      ieee754: 1.2.1
-
-  buffer@6.0.3:
     dependencies:
       base64-js: 1.5.1
       ieee754: 1.2.1


### PR DESCRIPTION
Bumps `@stellar/stellar-sdk` from `16.2.0` to `17.0.1` in `@lifi/sdk-provider-stellar`.

Step one of a four repo chain. Stellar Wallets Kit 2.6.0 requires
`@stellar/stellar-sdk ^17.0.0`, so this has to land and release before
`@lifi/widget`, then jumper widget, then jumper frontend can follow.

## What v17 breaks

v17 rebuilds the XDR namespace as a class based API and switches every byte
returning API from `Buffer` to `Uint8Array`.

**`deriveTransactionHash`** called `.toString('hex')` on `transaction.hash()`.
That returns a `Uint8Array` now, and its `toString` ignores the argument, so the
call would have produced comma separated decimals instead of a hex digest. The
migration guide flags this class of change as able to fail silently. Here
TypeScript caught it, because `Uint8Array.toString` takes no arguments. The
digest is encoded from the bytes now, and `StellarSignAndExecuteTask.unit.spec.ts`
already asserts the task output against an independently computed digest, so the
hand rolled encoder is cross checked on every run.

**`submitStellarTransaction`** and **`waitForStellarTransaction`** read the
failure reason through `result().switch().name`. The generated XDR classes expose
`result` as a readonly field carrying a `type` discriminant, so both read
`result.type`. Variant names are unchanged, and a new test pins the variant into
the error message.

**Deprecations.** `toXDR` and `TransactionBuilder.fromXDR` are both deprecated in
v17 and both remain as aliases. All seven call sites moved to `toXdr` and
`fromXdr` rather than leave deprecated calls in a change that exists to adopt v17.

## CAP-71, checked against mainnet rather than assumed

v17 sends `useUpgradedAuth: true` on every simulation instead of omitting the
key, which turns on CAP-71 address credentials. Three call sites simulate. The
two read paths, `readAllowance` and `getStellarBalance`, invoke contract methods
that need no authorization, so no credentials are recorded.

For the approve path I ran a live read only simulation against mainnet:

```
protocolVersion: 27
auth entries: 1
credential types: ["sorobanCredentialsSourceAccount"]
```

The authorizing address is the transaction source, so simulation records source
account credentials and the `ADDRESS` versus `ADDRESS_V2` choice never arises.
Mainnet is on protocol 27 in any case, which is what activates CAP-71. No
`useUpgradedAuth: false` pin is needed, so no deprecation debt is taken on.

## Why patch

`@stellar/stellar-sdk` is a plain dependency, not a peer, so consumers are not
forced to upgrade. Nothing is re-exported and no exported signature mentions its
types, so the public API is unchanged. Same reasoning as the
`@bitcoinerlab/secp256k1` 1 to 2 bump.

## Validation

| Check | Result |
|---|---|
| `check` (biome) | pass, 436 files |
| `check:types` | pass, all 7 packages |
| `check:circular-deps` | pass |
| `knip:check` | pass |
| `build` | pass |
| `test` | pass, zero failures, 92 Stellar provider tests |

CI runs Node 26, above the 22.12.0 floor v17 introduces.

One caveat worth stating plainly. The only test that reaches a real Stellar RPC,
`getStellarBalance.int.spec.ts`, is `describe.skip`. So the green check proves
nothing about how a live RPC handles the v17 request shape. The mainnet
simulation above is the evidence for that, not CI.
