### PR TITLE
fix(sdk-provider-stellar): bid live Soroban inclusion fee for approval tx

### DIFF
--- a/.changeset/stellar-soroban-inclusion-fee.md
+++ b/.changeset/stellar-soroban-inclusion-fee.md
@@ -1,0 +1,5 @@
+---
+"@lifi/sdk-provider-stellar": patch
+---
+
+Bid the live Soroban inclusion fee for the approval transaction instead of the network minimum, so it doesn't expire unincluded on a congested ledger.

--- a/packages/sdk-provider-stellar/src/core/tasks/helpers/buildApproveTransaction.ts
+++ b/packages/sdk-provider-stellar/src/core/tasks/helpers/buildApproveTransaction.ts
@@ -1,12 +1,12 @@
 import type { SDKClient } from '@lifi/sdk'
 import {
   Address,
-  BASE_FEE,
   Contract,
   nativeToScVal,
   TransactionBuilder,
 } from '@stellar/stellar-sdk'
 import { callStellarRpcsWithRetry } from '../../../client/getStellarRpc.js'
+import { resolveSorobanInclusionFee } from './resolveInclusionFee.js'
 
 /**
  * How long the granted allowance stays live, in ledgers. Ledgers close roughly
@@ -24,6 +24,11 @@ const APPROVAL_TTL_LEDGERS = 17_280
  * entries and resource fee into the envelope in one step — the client-side
  * equivalent of what the backend's invocation builder does for route
  * transactions.
+ *
+ * The inclusion fee is bid off the live distribution rather than left at
+ * `BASE_FEE`: this transaction is submitted, and a minimum bid on a busy
+ * Soroban ledger expires unincluded instead of failing. See
+ * {@link resolveSorobanInclusionFee}.
  */
 export const buildApproveTransaction = async (
   client: SDKClient,
@@ -34,13 +39,14 @@ export const buildApproveTransaction = async (
   networkPassphrase: string
 ): Promise<string> =>
   callStellarRpcsWithRetry(client, async (server) => {
-    const [account, latestLedger] = await Promise.all([
+    const [account, latestLedger, inclusionFee] = await Promise.all([
       server.getAccount(from),
       server.getLatestLedger(),
+      resolveSorobanInclusionFee(server),
     ])
 
     const transaction = new TransactionBuilder(account, {
-      fee: BASE_FEE,
+      fee: inclusionFee,
       networkPassphrase,
     })
       .addOperation(

--- a/packages/sdk-provider-stellar/src/core/tasks/helpers/resolveInclusionFee.ts
+++ b/packages/sdk-provider-stellar/src/core/tasks/helpers/resolveInclusionFee.ts
@@ -16,15 +16,26 @@ const MAX_FEE_STROOPS = 1_000_000
 /**
  * Percentile read for the inclusion bid.
  *
- * `p70` deliberately matches the percentile the backend bids when it builds the
- * route transaction, so the approval and the route it unblocks compete for
- * inclusion on equal terms. A cheaper approval is not a cheaper route — it is a
+ * `p70` matches the backend's `standard` fee tier — `getFeeTiers` in
+ * lifi-backend `apps/backend-api/src/stellar/gas/stellar.gas.ts` maps
+ * slow/standard/fast to p20/p70/p95, and the three constants above mirror that
+ * module. Bidding the same percentile keeps the approval and the route it
+ * unblocks on equal terms: a cheaper approval is not a cheaper route — it is a
  * route that never starts.
+ *
+ * Known limitation. `getFeeStats` reports the inclusion fees transactions were
+ * *charged*, not the fees they bid. Under surge pricing every transaction in an
+ * included set pays the lowest bid in that set, so the reported values cluster
+ * at recent clearing prices rather than spanning a range of bids — a 2026-09
+ * mainnet sample over ~7k transactions returned `p10` through `p99` all equal.
+ * A mid percentile of clearing prices is therefore a marginal bid. Raising it
+ * is worth doing, but only alongside the backend so the two stay aligned.
  */
 const INCLUSION_FEE_PERCENTILE = 'p70' as const
 
+/** Bounds a bid to an integer in range — the builder rejects non-integers. */
 const clampBid = (value: number): number =>
-  Math.min(MAX_FEE_STROOPS, Math.max(MIN_BASE_FEE, value))
+  Math.floor(Math.min(MAX_FEE_STROOPS, Math.max(MIN_BASE_FEE, value)))
 
 /**
  * Resolves the per-operation inclusion fee to bid for a Soroban transaction.
@@ -43,24 +54,31 @@ const clampBid = (value: number): number =>
  *
  * Fee stats are read best-effort: the surrounding RPC failover has already
  * proven this server answers, so a `getFeeStats` hiccup falls back to a bid
- * rather than failing the approval.
+ * rather than failing the approval. Both degraded paths warn, because a silent
+ * fallback re-creates the undiagnosable failure this helper exists to remove.
  */
 export const resolveSorobanInclusionFee = async (
   server: Server
 ): Promise<string> => {
   try {
     const feeStats = await server.getFeeStats()
-    const percentile = Number(
-      feeStats?.sorobanInclusionFee?.[INCLUSION_FEE_PERCENTILE]
-    )
-    return String(
-      clampBid(
-        Number.isFinite(percentile) && percentile > 0
-          ? percentile
-          : FALLBACK_FEE
+    const reported = feeStats?.sorobanInclusionFee?.[INCLUSION_FEE_PERCENTILE]
+    const percentile = Number(reported)
+    if (!Number.isFinite(percentile) || percentile <= 0) {
+      console.warn(
+        '[resolveSorobanInclusionFee] Unusable fee percentile, using fallback bid:',
+        FALLBACK_FEE,
+        reported
       )
+      return String(FALLBACK_FEE)
+    }
+    return String(clampBid(percentile))
+  } catch (error) {
+    console.warn(
+      '[resolveSorobanInclusionFee] Fee stats unreadable, using fallback bid:',
+      FALLBACK_FEE,
+      error
     )
-  } catch {
-    return String(clampBid(FALLBACK_FEE))
+    return String(FALLBACK_FEE)
   }
 }

--- a/packages/sdk-provider-stellar/src/core/tasks/helpers/resolveInclusionFee.ts
+++ b/packages/sdk-provider-stellar/src/core/tasks/helpers/resolveInclusionFee.ts
@@ -1,0 +1,66 @@
+import { BASE_FEE } from '@stellar/stellar-sdk'
+import type { Server } from '@stellar/stellar-sdk/rpc'
+
+/** stroops/op — the network minimum, and the floor under any bid. */
+const MIN_BASE_FEE = Number(BASE_FEE)
+
+/** stroops/op — the bid placed when fee stats cannot be read or decoded. */
+const FALLBACK_FEE = 10_000
+
+/**
+ * stroops/op cap (0.1 XLM). A broken RPC percentile must never reach a real
+ * bid, so the ceiling is enforced even on a value the network reported.
+ */
+const MAX_FEE_STROOPS = 1_000_000
+
+/**
+ * Percentile read for the inclusion bid.
+ *
+ * `p70` deliberately matches the percentile the backend bids when it builds the
+ * route transaction, so the approval and the route it unblocks compete for
+ * inclusion on equal terms. A cheaper approval is not a cheaper route — it is a
+ * route that never starts.
+ */
+const INCLUSION_FEE_PERCENTILE = 'p70' as const
+
+const clampBid = (value: number): number =>
+  Math.min(MAX_FEE_STROOPS, Math.max(MIN_BASE_FEE, value))
+
+/**
+ * Resolves the per-operation inclusion fee to bid for a Soroban transaction.
+ *
+ * `BASE_FEE` is the network *minimum*, not a market price: Soroban validators
+ * rank transactions by the inclusion component alone, and when the Soroban
+ * ledger is at capacity every included transaction pays well above the minimum.
+ * A minimum bid is then accepted into the mempool, never wins a slot, and dies
+ * silently when its timebound expires — `sendTransaction` reports `PENDING` and
+ * `getTransaction` reports `NOT_FOUND` forever, with nothing on chain to
+ * explain it. Reading the live distribution is what avoids that.
+ *
+ * Note the resource fee cannot substitute for this. `prepareTransaction` folds
+ * a large resource fee into the total, but that buys nothing in the inclusion
+ * queue.
+ *
+ * Fee stats are read best-effort: the surrounding RPC failover has already
+ * proven this server answers, so a `getFeeStats` hiccup falls back to a bid
+ * rather than failing the approval.
+ */
+export const resolveSorobanInclusionFee = async (
+  server: Server
+): Promise<string> => {
+  try {
+    const feeStats = await server.getFeeStats()
+    const percentile = Number(
+      feeStats?.sorobanInclusionFee?.[INCLUSION_FEE_PERCENTILE]
+    )
+    return String(
+      clampBid(
+        Number.isFinite(percentile) && percentile > 0
+          ? percentile
+          : FALLBACK_FEE
+      )
+    )
+  } catch {
+    return String(clampBid(FALLBACK_FEE))
+  }
+}

--- a/packages/sdk-provider-stellar/src/core/tasks/helpers/resolveInclusionFee.unit.spec.ts
+++ b/packages/sdk-provider-stellar/src/core/tasks/helpers/resolveInclusionFee.unit.spec.ts
@@ -1,0 +1,77 @@
+import { BASE_FEE } from '@stellar/stellar-sdk'
+import type { Server } from '@stellar/stellar-sdk/rpc'
+import { describe, expect, it, vi } from 'vitest'
+
+import { resolveSorobanInclusionFee } from './resolveInclusionFee.js'
+
+const FALLBACK_FEE = '10000'
+const MAX_FEE_STROOPS = '1000000'
+
+/** A server whose `getFeeStats` resolves to the given soroban distribution. */
+const serverWith = (sorobanInclusionFee: unknown): Server =>
+  ({
+    getFeeStats: vi.fn().mockResolvedValue({ sorobanInclusionFee }),
+  }) as unknown as Server
+
+const failingServer = (): Server =>
+  ({
+    getFeeStats: vi.fn().mockRejectedValue(new Error('rpc down')),
+  }) as unknown as Server
+
+describe('resolveSorobanInclusionFee', () => {
+  it('bids the p70 percentile of the soroban distribution', async () => {
+    const server = serverWith({ p50: '150', p70: '200', p95: '400' })
+
+    await expect(resolveSorobanInclusionFee(server)).resolves.toBe('200')
+  })
+
+  it('bids above the network minimum when the market is above it', async () => {
+    const server = serverWith({ p70: '200' })
+
+    const fee = await resolveSorobanInclusionFee(server)
+
+    // the whole point: BASE_FEE is a floor, not a price. A bid equal to the
+    // minimum on a busy ledger expires unincluded.
+    expect(Number(fee)).toBeGreaterThan(Number(BASE_FEE))
+  })
+
+  it('floors a below-minimum percentile at the network minimum', async () => {
+    const server = serverWith({ p70: '1' })
+
+    await expect(resolveSorobanInclusionFee(server)).resolves.toBe(BASE_FEE)
+  })
+
+  it('caps an absurd percentile so a broken RPC cannot drain the fee', async () => {
+    const server = serverWith({ p70: '999999999' })
+
+    await expect(resolveSorobanInclusionFee(server)).resolves.toBe(
+      MAX_FEE_STROOPS
+    )
+  })
+
+  it('falls back when the percentile is missing', async () => {
+    const server = serverWith({ p50: '200' })
+
+    await expect(resolveSorobanInclusionFee(server)).resolves.toBe(FALLBACK_FEE)
+  })
+
+  it('falls back when the distribution is absent entirely', async () => {
+    const server = serverWith(undefined)
+
+    await expect(resolveSorobanInclusionFee(server)).resolves.toBe(FALLBACK_FEE)
+  })
+
+  it('falls back when the percentile is not a number', async () => {
+    const server = serverWith({ p70: 'not-a-fee' })
+
+    await expect(resolveSorobanInclusionFee(server)).resolves.toBe(FALLBACK_FEE)
+  })
+
+  it('falls back rather than failing when getFeeStats rejects', async () => {
+    // the surrounding RPC failover has already proven the server answers, so a
+    // fee-stats hiccup must not block the approval
+    await expect(resolveSorobanInclusionFee(failingServer())).resolves.toBe(
+      FALLBACK_FEE
+    )
+  })
+})

--- a/packages/sdk-provider-stellar/src/core/tasks/helpers/resolveInclusionFee.unit.spec.ts
+++ b/packages/sdk-provider-stellar/src/core/tasks/helpers/resolveInclusionFee.unit.spec.ts
@@ -1,6 +1,6 @@
 import { BASE_FEE } from '@stellar/stellar-sdk'
 import type { Server } from '@stellar/stellar-sdk/rpc'
-import { describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { resolveSorobanInclusionFee } from './resolveInclusionFee.js'
 
@@ -19,6 +19,14 @@ const failingServer = (): Server =>
   }) as unknown as Server
 
 describe('resolveSorobanInclusionFee', () => {
+  beforeEach(() => {
+    vi.spyOn(console, 'warn').mockImplementation(() => {})
+  })
+
+  afterEach(() => {
+    vi.resetAllMocks()
+  })
+
   it('bids the p70 percentile of the soroban distribution', async () => {
     const server = serverWith({ p50: '150', p70: '200', p95: '400' })
 
@@ -49,6 +57,15 @@ describe('resolveSorobanInclusionFee', () => {
     )
   })
 
+  it('drops a fractional part, which the transaction builder rejects', async () => {
+    // TransactionBuilder throws 'Transaction.fee: expected integer in range
+    // 0..4294967295', and the throw sits inside the RPC failover callback — so
+    // a fractional percentile would look like an outage of every RPC.
+    const server = serverWith({ p70: '150.5' })
+
+    await expect(resolveSorobanInclusionFee(server)).resolves.toBe('150')
+  })
+
   it('falls back when the percentile is missing', async () => {
     const server = serverWith({ p50: '200' })
 
@@ -72,6 +89,22 @@ describe('resolveSorobanInclusionFee', () => {
     // fee-stats hiccup must not block the approval
     await expect(resolveSorobanInclusionFee(failingServer())).resolves.toBe(
       FALLBACK_FEE
+    )
+  })
+
+  it('warns on every degraded path so the fallback is never silent', async () => {
+    await resolveSorobanInclusionFee(serverWith({ p50: '200' }))
+    expect(console.warn).toHaveBeenCalledWith(
+      expect.stringContaining('Unusable fee percentile'),
+      10_000,
+      undefined
+    )
+
+    await resolveSorobanInclusionFee(failingServer())
+    expect(console.warn).toHaveBeenCalledWith(
+      expect.stringContaining('Fee stats unreadable'),
+      10_000,
+      expect.any(Error)
     )
   })
 })


### PR DESCRIPTION
## Which Linear task is linked to this PR?
EXBE-546

## Why was it implemented this way?
`buildApproveTransaction` was hardcoding `fee: BASE_FEE` (the network minimum) on the Stellar approval transaction. Soroban validators rank transactions by the inclusion fee component alone, so on a congested ledger a minimum-fee transaction gets accepted into the mempool but never wins a block slot — it expires silently (`sendTransaction` reports `PENDING`, then `getTransaction` reports `NOT_FOUND` forever), with nothing on chain to explain it.

Added `resolveSorobanInclusionFee`, which reads the live fee distribution via `getFeeStats()` and bids the `p70` percentile — the same percentile the backend bids when building the route transaction, so the approval doesn't lose the inclusion race to the route it's meant to unblock. The bid is clamped between the network minimum and a 0.1 XLM ceiling, and falls back to a flat bid if `getFeeStats()` is unreadable (best-effort, since the surrounding RPC failover already proved the server is reachable).

## Visual showcase (Screenshots or Videos)
N/A — backend fee-bidding logic, no UI change.

## Checklist before requesting a review
- [x] I have performed a self-review and testing of my code.
- [x] This pull request is focused and addresses a single problem.
- [ ] If this PR modifies the SDK API or adds new features that require documentation, I have updated the documentation in the public-docs repository.